### PR TITLE
Data/30 feature engineering (RFM, session, sequence, store, dictionary)

### DIFF
--- a/docs/feature_dictionary.md
+++ b/docs/feature_dictionary.md
@@ -1,0 +1,225 @@
+# Feature Dictionary
+
+> AI 기반 고객 이탈 예측 및 리텐션 ROI 최적화 시스템
+> 본 문서는 `src/features/` 모듈이 산출하는 모든 피처의 정의/계산식/비즈니스 의미를 정리한 사전이다.
+> 데이터 입력은 시뮬레이터 산출물 (`data/raw/customers.csv`, `data/raw/events.csv`) 이며,
+> 통합 산출물은 `data/processed/feature_store.csv (.parquet)` 에 저장된다.
+
+## 산출 모듈 개요
+
+| 모듈 | 책임 | 산출 컬럼 수 |
+|---|---|---|
+| `src/features/rfm.py` | RFM + 행동 변화율 | 18 |
+| `src/features/session.py` | 세션 품질 + 시간대별 행동 | 13 |
+| `src/features/sequence.py` | 시퀀스 + 고객 여정 단계 | 13 |
+| `src/features/store.py` | 결측/이상치 처리 + 통합 저장 | (스토어) |
+| **합계 (식별/타깃 제외)** | | **44** |
+
+식별/타깃 컬럼 (피처가 아닌 메타데이터): `customer_id`, `persona`, `is_treatment`, `churned`.
+
+분석 기준일은 **`events["event_date"].max() + 1day`** 로 통일한다 (`get_analysis_date`).
+
+---
+
+## 1. RFM 피처 (`rfm.py`)
+
+명세: "RFM 피처(Recency, Frequency, Monetary)를 산출해야 한다."
+
+| # | 피처명 | 타입 | 정의 / 계산식 | 비즈니스 의미 |
+|---|---|---|---|---|
+| 1 | `recency_days` | float | 분석 기준일 − 마지막 구매일 (구매 없으면 가입일 기준) | 최근성. 클수록 이탈 위험 |
+| 2 | `frequency` | int | `purchase` 이벤트 횟수 | 구매 활성도 |
+| 3 | `monetary` | float | 모든 `order_value` 의 합 | 누적 가치 |
+| 4 | `avg_order_value` | float | `monetary / frequency` (frequency==0 → 0) | 객단가 |
+| 5 | `rfm_r_score` | float | `recency_days` 5분위 (1=오래됨, 5=최근) | RFM 세그먼트용 |
+| 6 | `rfm_f_score` | float | `frequency` 5분위 (5=많음) | RFM 세그먼트용 |
+| 7 | `rfm_m_score` | float | `monetary` 5분위 (5=많음) | RFM 세그먼트용 |
+| 8 | `rfm_score` | float | R+F+M 합산 (3~15) | RFM 통합 점수 |
+| 9 | `days_since_last_purchase` | float | `recency_days` 와 동일 (해석성용 alias) | 명세서 호환 |
+| 10 | `avg_purchase_cycle_days` | float | 구매 간 일수 평균 (구매 ≥2회만 산출, 그 외 −1) | 구매 주기 |
+| 11 | `purchase_cycle_anomaly` | float | `recency_days / avg_purchase_cycle_days` | **명세서 요구**: 현재 미구매 일수 / 평균 구매 주기. 1을 크게 넘으면 평소보다 오래 미구매 |
+
+---
+
+## 2. 행동 변화율 피처 (`rfm.py`)
+
+명세: "행동 변화율 피처를 최소 5개 이상 설계해야 한다."
+
+윈도 정의: `recent` = 분석 기준일 직전 14일, `prior` = 그 직전 14일.
+
+| # | 피처명 | 타입 | 정의 / 계산식 | 비즈니스 의미 |
+|---|---|---|---|---|
+| 12 | `visit_change_rate` | float | recent 방문일 수 / prior 방문일 수 | **명세서 예시 #1**: 최근 2주 방문수/이전 2주 방문수. <1 이면 방문 감소 |
+| 13 | `purchase_cycle_change_rate` | float | recent 평균 구매 주기 / prior 평균 구매 주기 | **명세서 예시 #2**: 구매 주기 변화율. >1 이면 주기 길어짐(=이탈 신호) |
+| 14 | `session_duration_change_rate` | float | recent 활동일당 이벤트 수 / prior 활동일당 이벤트 수 | **명세서 예시 #3**: 세션 시간 변화율 (이벤트 수 proxy) |
+| 15 | `cart_conversion_change` | float | recent 장바구니→구매 전환율 − prior 동일 | **명세서 예시 #4**: 장바구니 전환율 변화 |
+| 16 | `coupon_response_change` | float | recent 쿠폰 사용 비율 − prior 동일 | **명세서 예시 #5**: 쿠폰 반응률 변화 |
+| 17 | `event_volume_change_rate` | float | recent 전체 이벤트 수 / prior 전체 이벤트 수 | 종합 활동량 변화 |
+| 18 | `activity_decline_flag` | int | `visit_change_rate < 0.5` 이면 1 | 활동 급감 플래그 (이탈 직전 신호) |
+
+---
+
+## 3. 세션 품질 피처 (`session.py`)
+
+명세: "세션 품질 피처(평균 세션 시간, 페이지뷰/세션, 검색 후 구매 전환율) 최소 3개 이상."
+
+세션 정의: 같은 고객의 같은 날짜 이벤트 묶음 (시뮬레이터 시각 정밀도가 일 단위이므로).
+
+| # | 피처명 | 타입 | 정의 / 계산식 | 비즈니스 의미 |
+|---|---|---|---|---|
+| 19 | `avg_session_length` | float | 세션당 평균 이벤트 수 | **명세서 요구**: 평균 세션 시간 (이벤트 수 proxy) |
+| 20 | `avg_pageviews_per_session` | float | 세션당 평균 `page_view` 수 | **명세서 요구**: 페이지뷰/세션 |
+| 21 | `search_to_purchase_rate` | float | `search` 후 7일 내 `purchase` 가 있는 검색 비율 | **명세서 요구**: 검색 후 구매 전환율 |
+| 22 | `total_sessions` | int | 활동한 unique 날짜 수 (=세션 수) | 활동 빈도 |
+| 23 | `bounce_rate` | float | 이벤트 1개로 끝난 세션 비율 | 이탈로 신호 (높을수록 위험) |
+| 24 | `avg_event_diversity` | float | 세션당 unique 이벤트 타입 수 | 행동 다양성 |
+
+---
+
+## 4. 시간대별 행동 피처 (`session.py`)
+
+명세: "시간대별 행동 피처(주말/평일 구매 비율, 특정 시간대 활동 비율)."
+
+> 시뮬레이터 timestamp 가 일 단위 정밀도이므로 시(hour) 단위 피처는 산출 불가.
+> "특정 시간대"는 월초(1~7일)/월말(25일~) 활동 비율로 대체한다.
+
+| # | 피처명 | 타입 | 정의 / 계산식 | 비즈니스 의미 |
+|---|---|---|---|---|
+| 25 | `weekend_purchase_ratio` | float | 토/일에 발생한 구매 비율 | **명세서 요구**: 주말 구매 비율 |
+| 26 | `weekend_visit_ratio` | float | 토/일에 발생한 `page_view` 비율 | 주말 활동 패턴 |
+| 27 | `weekday_event_ratio` | float | 월~금 이벤트 비율 (=1 − 주말) | 평일 활동 패턴 |
+| 28 | `month_end_activity_ratio` | float | 월말(25일~) 이벤트 비율 | 급여일 효과 / 월말 패턴 |
+| 29 | `month_start_activity_ratio` | float | 월초(1~7일) 이벤트 비율 | 월초 패턴 |
+| 30 | `active_day_span` | int | 첫 ~ 마지막 이벤트일 사이 일수 | 고객 수명 |
+| 31 | `active_day_ratio` | float | 활동일 수 / `active_day_span` | 활동 밀도. 낮을수록 산발적 |
+
+---
+
+## 5. 시퀀스 피처 (`sequence.py`)
+
+명세: "시퀀스 피처를 최소 2개 이상 설계 (예: 최근 N개 이벤트 타입 시퀀스 임베딩, 행동 패턴 클러스터 ID)."
+
+`SEQUENCE_LENGTH=20` 으로 가장 최근 20개 이벤트를 윈도로 사용.
+
+| # | 피처명 | 타입 | 정의 / 계산식 | 비즈니스 의미 |
+|---|---|---|---|---|
+| 32 | `seq_entropy` | float | 최근 20개 이벤트 타입 분포의 Shannon entropy | 낮을수록 행동 단조 → 이탈 신호 |
+| 33 | `seq_unique_event_types` | int | 최근 20개 내 unique 이벤트 타입 수 | 행동 다양성 |
+| 34 | `seq_transition_count` | int | 최근 20개에서 직전 이벤트와 타입이 바뀐 횟수 | 행동 전환 빈도 |
+| 35 | `seq_purchase_position` | float | 최근 20개 중 마지막 `purchase` 의 뒤에서 본 위치 (0=가장 최근, 없음=−1) | 최근 구매 위치 |
+| 36 | `seq_dominant_event_id` | int | 최근 20개 중 가장 많은 이벤트 타입의 정수 인덱스 (vocab 기준 0~7, 없음=−1) | 주요 행동 카테고리 |
+| 37 | `behavior_cluster_id` | int | 전체 이벤트 분포 기반 KMeans (k=5) 클러스터 ID | **명세서 예시**: 행동 패턴 클러스터 ID |
+
+이벤트 vocab: `page_view, search, add_to_cart, remove_from_cart, purchase, coupon_use, review, cs_contact` (인덱스 0~7).
+
+---
+
+## 6. 고객 여정 단계 피처 (`sequence.py`)
+
+명세: "고객 여정 단계 피처(현재 여정 단계, 단계별 체류 기간)를 산출해야 한다."
+
+여정 단계 정의 (명세서: 가입 → 첫구매 → 재구매 → 충성 → 이탈):
+
+| stage | id | 조건 |
+|---|---|---|
+| `new` | 0 | 구매 0회 (가입만) |
+| `first_buy` | 1 | 구매 1회 |
+| `repeat` | 2 | 구매 2~4회 |
+| `loyal` | 3 | 구매 5회 이상 |
+| `churned` | 4 | `customers.churned == 1` |
+
+| # | 피처명 | 타입 | 정의 / 계산식 | 비즈니스 의미 |
+|---|---|---|---|---|
+| 38 | `journey_stage` | str | 위 분류 결과 (`new`/`first_buy`/`repeat`/`loyal`/`churned`) | **명세서 요구**: 현재 여정 단계 |
+| 39 | `journey_stage_id` | float | `journey_stage` 의 정수 인코딩 (0~4) | 모델 입력용 |
+| 40 | `days_in_current_stage` | float | 현재 단계 진입일로부터 경과 일수 | **명세서 요구**: 단계별 체류 기간 |
+| 41 | `purchase_count` | int | 총 구매 횟수 (단계 분류 근거) | 단계 판정 보조 |
+| 42 | `days_since_signup` | int | 가입 후 경과 일수 | 고객 수명 |
+| 43 | `cart_abandon_count_recent` | float | 최근 30일 `remove_from_cart` 빈도 | **명세서 요구**: 이탈 직전 장바구니 포기 |
+| 44 | `cs_contact_count_recent` | float | 최근 30일 `cs_contact` 빈도 | **명세서 요구**: 이탈 직전 CS 문의 |
+
+---
+
+## 7. 결측치 / 이상치 처리 (`store.py`)
+
+명세: "모든 피처에 대해 결측치 처리와 이상치 처리 로직을 구현해야 한다."
+
+### 7.1 결측치 처리 정책
+
+| 피처 그룹 | 정책 | 충전값 |
+|---|---|---|
+| 빈도/카운트형 (`frequency`, `total_sessions`, `purchase_count`, ...) | 상수 충전 | 0 |
+| 변화율형 (`*_change_rate`) | 상수 충전 (변화 없음) | 1.0 |
+| 차이형 (`*_change`) | 상수 충전 (변화 없음) | 0.0 |
+| 평균 구매 주기 미정의 (`avg_purchase_cycle_days`, `purchase_cycle_anomaly`) | 상수 충전 (sentinel) | −1.0 |
+| 시퀀스 미정의 (`seq_purchase_position`, `seq_dominant_event_id`, `behavior_cluster_id`) | 상수 충전 (sentinel) | −1 |
+| 그 외 수치형 | 중앙값 (median) | — |
+| 그 외 범주형 | 최빈값 (mode) | — |
+
+### 7.2 이상치 처리 정책
+
+- 방법: 분위수 기반 winsorization
+- 임계: 하위 1% / 상위 99%
+- 제외 컬럼: `customer_id`, RFM 점수(이미 5분위), 플래그/카테고리/식별자 (`activity_decline_flag`, `journey_stage_id`, `behavior_cluster_id`, `seq_dominant_event_id`, `seq_unique_event_types`)
+- ±∞ 는 NaN 으로 치환 후 결측 처리 단계에서 충전
+
+### 7.3 처리 로그
+
+`data/processed/feature_store_meta.json` 에 컬럼별 처리 통계가 저장된다:
+- 결측 처리: 컬럼별 결측 개수/비율, 충전 전략, 충전값
+- 이상치 처리: 컬럼별 클리핑 경계, 클리핑된 행 수
+
+---
+
+## 8. 피처 스토어 출력
+
+`src/features/store.py` 실행 시 다음 파일이 생성된다:
+
+| 경로 | 용도 |
+|---|---|
+| `data/processed/feature_store.parquet` | 빠른 재로드 (pyarrow) |
+| `data/processed/feature_store.csv` | 검토 / 디버깅 / 외부 도구 호환 |
+| `data/processed/feature_store_meta.json` | 처리 통계 + 피처 목록 |
+
+스키마: `customer_id`, `persona`, `is_treatment`, `churned`, + 위의 44개 피처.
+
+### 사용 예 (Python)
+
+```python
+from features.store import build_feature_store, load_feature_store
+
+# 빌드 + 저장
+fs = build_feature_store(data_dir="data/raw", output_dir="data/processed")
+
+# 재로드 (학습 시)
+fs = load_feature_store("data/processed")
+```
+
+### 사용 예 (CLI)
+
+```bash
+# 개별 모듈
+python src/features/rfm.py
+python src/features/session.py
+python src/features/sequence.py
+
+# 통합 스토어 (위 3개를 모두 호출함)
+python src/features/store.py
+```
+
+---
+
+## 9. 명세서 요구사항 체크리스트
+
+| # | 명세서 요구사항 | 충족 여부 | 근거 |
+|---|---|---|---|
+| 1 | RFM 피처 산출 | ✅ | #1~#11 |
+| 2 | 행동 변화율 피처 5개 이상 | ✅ | #12~#18 (총 7개) |
+| 3 | 구매 주기 이상 피처 | ✅ | #11 `purchase_cycle_anomaly` |
+| 4 | 세션 품질 피처 3개 이상 | ✅ | #19~#24 (총 6개) |
+| 5 | 시퀀스 피처 2개 이상 | ✅ | #32~#37 (총 6개) |
+| 6 | 시간대별 행동 피처 | ✅ | #25~#31 |
+| 7 | 고객 여정 단계 피처 | ✅ | #38~#44 |
+| 8 | 결측치/이상치 처리 | ✅ | §7 + `store.py` |
+| 9 | 피처 스토어 저장 (Redis 또는 파일) | ✅ | §8 (parquet + csv 파일 기반) |
+| 10 | feature_dictionary.md 30개 이상 | ✅ | 본 문서 44개 |

--- a/src/features/__init__.py
+++ b/src/features/__init__.py
@@ -1,0 +1,9 @@
+"""Feature engineering package — Task 3.x.
+
+Modules
+-------
+rfm       : RFM + behavioral change-rate features
+session   : session-quality + time-based features
+sequence  : sequence + customer journey features
+store     : feature store with missing/outlier handling
+"""

--- a/src/features/rfm.py
+++ b/src/features/rfm.py
@@ -1,0 +1,457 @@
+"""RFM and behavioral-change-rate feature engineering — Task 3.2.
+
+시뮬레이터 출력(data/raw/customers.csv, events.csv)을 입력으로 받아
+RFM 피처와 행동 변화율 피처를 산출한다.
+
+명세서 요구사항
+---------------
+- RFM 피처(Recency, Frequency, Monetary)를 산출해야 한다.
+- 행동 변화율 피처를 최소 5개 이상 설계해야 한다.
+  * 최근 2주 방문수 / 이전 2주 방문수
+  * 구매 주기 변화율
+  * 세션 시간 변화율
+  * 장바구니 전환율 변화
+  * 쿠폰 반응률 변화
+- 구매 주기 이상 피처(현재 미구매 일수 / 평균 구매 주기)를 산출해야 한다.
+
+Simulator output schema
+-----------------------
+customers.csv : customer_id, persona, is_treatment, signup_date, churned, scheduled_churn_day
+events.csv    : customer_id, event_date, event_type, persona, is_treatment, order_value
+
+Usage
+-----
+    python src/features/rfm.py
+    python src/features/rfm.py --data-dir data/raw --output-dir data/processed
+
+    # 모듈로 사용
+    from features.rfm import compute_rfm_features, compute_change_rate_features
+
+    rfm = compute_rfm_features(customers, events, analysis_date)
+    change = compute_change_rate_features(customers, events, analysis_date)
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+# 행동 변화율 산출 시 사용하는 윈도 길이 (일)
+RECENT_WINDOW_DAYS: int = 14   # "최근 2주"
+PRIOR_WINDOW_DAYS: int = 14    # "이전 2주"
+
+# 0으로 나누기 방지용 작은 값
+EPSILON: float = 1e-6
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
+
+def load_data(data_dir: str | Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Load simulator outputs and parse date columns.
+
+    Returns
+    -------
+    customers : DataFrame with parsed signup_date
+    events    : DataFrame with parsed event_date
+    """
+    data_dir = Path(data_dir)
+    customers = pd.read_csv(data_dir / "customers.csv")
+    events = pd.read_csv(data_dir / "events.csv")
+
+    customers["signup_date"] = pd.to_datetime(customers["signup_date"], errors="coerce")
+    events["event_date"] = pd.to_datetime(events["event_date"], errors="coerce")
+    events = events.dropna(subset=["event_date"]).copy()
+
+    return customers, events
+
+
+def get_analysis_date(events: pd.DataFrame) -> pd.Timestamp:
+    """분석 기준일 = 마지막 이벤트 다음날.
+
+    notebooks/eda.ipynb 의 RFM 정의와 동일한 규칙을 사용한다.
+    """
+    return events["event_date"].max() + pd.Timedelta(days=1)
+
+
+# ---------------------------------------------------------------------------
+# RFM features
+# ---------------------------------------------------------------------------
+
+def compute_rfm_features(
+    customers: pd.DataFrame,
+    events: pd.DataFrame,
+    analysis_date: pd.Timestamp | None = None,
+) -> pd.DataFrame:
+    """RFM 피처를 산출한다 (구매 이력 없는 고객 포함).
+
+    산출 컬럼
+    ---------
+    recency_days       : 마지막 구매(없으면 가입일)로부터의 경과 일수
+    frequency          : 구매(=purchase 이벤트) 횟수
+    monetary           : order_value 총합
+    avg_order_value    : 1회당 평균 주문 금액 (frequency==0 → 0)
+    rfm_r_score        : Recency 5분위 (1=최근, 5=오래됨)
+    rfm_f_score        : Frequency 5분위 (5=많음)
+    rfm_m_score        : Monetary 5분위 (5=많음)
+    rfm_score          : R+F+M 합산 점수 (3~15)
+    days_since_last_purchase  : recency_days alias (해석성)
+    avg_purchase_cycle_days   : 구매 간 평균 일수 (미구매/단일구매=NaN)
+    purchase_cycle_anomaly    : 현재 미구매 일수 / 평균 구매 주기
+
+    Parameters
+    ----------
+    customers : 시뮬레이터 customers.csv (signup_date 파싱 완료)
+    events    : 시뮬레이터 events.csv (event_date 파싱 완료)
+    analysis_date : 분석 기준일. None 이면 events 마지막일 +1
+    """
+    if analysis_date is None:
+        analysis_date = get_analysis_date(events)
+    analysis_date = pd.Timestamp(analysis_date)
+
+    purchases = events[events["event_type"] == "purchase"].copy()
+
+    # Recency: 마지막 구매일
+    last_purchase = (
+        purchases.groupby("customer_id")["event_date"].max().rename("last_purchase_date")
+    )
+    # Frequency / Monetary
+    frequency = purchases.groupby("customer_id").size().rename("frequency")
+    monetary = purchases.groupby("customer_id")["order_value"].sum().rename("monetary")
+
+    rfm = customers[["customer_id", "signup_date"]].copy()
+    rfm = rfm.merge(last_purchase, on="customer_id", how="left")
+    rfm = rfm.merge(frequency, on="customer_id", how="left")
+    rfm = rfm.merge(monetary, on="customer_id", how="left")
+
+    rfm["frequency"] = rfm["frequency"].fillna(0).astype(int)
+    rfm["monetary"] = rfm["monetary"].fillna(0).astype(float)
+
+    # Recency: 비구매자는 가입일 기준
+    rfm["recency_days"] = np.where(
+        rfm["last_purchase_date"].notna(),
+        (analysis_date - rfm["last_purchase_date"]).dt.days,
+        (analysis_date - rfm["signup_date"]).dt.days,
+    ).astype(float)
+    rfm["days_since_last_purchase"] = rfm["recency_days"]
+
+    rfm["avg_order_value"] = np.where(
+        rfm["frequency"] > 0, rfm["monetary"] / rfm["frequency"].clip(lower=1), 0.0
+    )
+
+    # 평균 구매 주기 (구매 2회 이상인 고객만 산출)
+    cycle_map = _compute_avg_purchase_cycle(purchases)
+    rfm = rfm.merge(cycle_map, on="customer_id", how="left")
+
+    # 구매 주기 이상 피처: 현재 미구매 일수 / 평균 구매 주기
+    rfm["purchase_cycle_anomaly"] = (
+        rfm["recency_days"] / rfm["avg_purchase_cycle_days"]
+    )
+
+    # RFM 5분위 점수
+    rfm["rfm_r_score"] = _quantile_score(rfm["recency_days"], reverse=True)
+    rfm["rfm_f_score"] = _quantile_score(rfm["frequency"], reverse=False)
+    rfm["rfm_m_score"] = _quantile_score(rfm["monetary"], reverse=False)
+    rfm["rfm_score"] = (
+        rfm["rfm_r_score"] + rfm["rfm_f_score"] + rfm["rfm_m_score"]
+    ).astype(float)
+
+    output_cols = [
+        "customer_id",
+        "recency_days",
+        "frequency",
+        "monetary",
+        "avg_order_value",
+        "rfm_r_score",
+        "rfm_f_score",
+        "rfm_m_score",
+        "rfm_score",
+        "days_since_last_purchase",
+        "avg_purchase_cycle_days",
+        "purchase_cycle_anomaly",
+    ]
+    return rfm[output_cols]
+
+
+def _compute_avg_purchase_cycle(purchases: pd.DataFrame) -> pd.DataFrame:
+    """고객별 평균 구매 주기(일)를 산출한다.
+
+    구매 2회 이상인 고객만 산출되며, 단일/0회 구매 고객은 NaN.
+    """
+    if purchases.empty:
+        return pd.DataFrame(columns=["customer_id", "avg_purchase_cycle_days"])
+
+    sorted_purchases = purchases.sort_values(["customer_id", "event_date"])
+    sorted_purchases["prev_date"] = (
+        sorted_purchases.groupby("customer_id")["event_date"].shift(1)
+    )
+    sorted_purchases["gap_days"] = (
+        sorted_purchases["event_date"] - sorted_purchases["prev_date"]
+    ).dt.days
+
+    cycle = (
+        sorted_purchases.dropna(subset=["gap_days"])
+        .groupby("customer_id")["gap_days"]
+        .mean()
+        .rename("avg_purchase_cycle_days")
+        .reset_index()
+    )
+    return cycle
+
+
+def _quantile_score(s: pd.Series, reverse: bool, n_bins: int = 5) -> pd.Series:
+    """Series → 1~n_bins 정수 점수 (5분위).
+
+    reverse=True : 작은 값일수록 높은 점수 (Recency용 — 최근일수록 좋음)
+    reverse=False: 큰 값일수록 높은 점수 (Frequency, Monetary용)
+
+    값이 한 점에 몰려 분위 경계가 만들어지지 않는 경우 (예: monetary=0이 전체의 50%+)
+    qcut이 실패하므로 rank 기반 fallback을 사용한다.
+    """
+    try:
+        ranks = pd.qcut(s.rank(method="first"), q=n_bins, labels=False, duplicates="drop")
+        scores = ranks + 1
+    except ValueError:
+        scores = pd.Series([3] * len(s), index=s.index)
+
+    scores = scores.fillna(3).astype(int)
+    if reverse:
+        scores = (n_bins + 1) - scores
+    return scores.astype(float)
+
+
+# ---------------------------------------------------------------------------
+# Behavioral change-rate features (5+)
+# ---------------------------------------------------------------------------
+
+def compute_change_rate_features(
+    customers: pd.DataFrame,
+    events: pd.DataFrame,
+    analysis_date: pd.Timestamp | None = None,
+    recent_days: int = RECENT_WINDOW_DAYS,
+    prior_days: int = PRIOR_WINDOW_DAYS,
+) -> pd.DataFrame:
+    """행동 변화율 피처를 산출한다.
+
+    명세서 예시 5개를 모두 구현한다.
+        1. visit_change_rate            : 최근 2주 방문수 / 이전 2주 방문수
+        2. purchase_cycle_change_rate   : 최근 평균 구매 주기 / 이전 평균 구매 주기
+        3. session_duration_change_rate : 최근 평균 세션 길이 / 이전 평균 세션 길이
+                                          (세션 = 같은 날짜의 이벤트 묶음으로 근사,
+                                           이벤트 수 기반 proxy)
+        4. cart_conversion_change       : 최근 장바구니 전환율 - 이전 장바구니 전환율
+                                          (장바구니→구매)
+        5. coupon_response_change       : 최근 쿠폰 반응률 - 이전 쿠폰 반응률
+
+    추가 보너스:
+        6. event_volume_change_rate     : 최근 전체 이벤트 수 / 이전 전체 이벤트 수
+        7. activity_decline_flag        : 최근/이전 비율이 0.5 미만인지 (이탈 징후 플래그)
+
+    분모가 0인 경우는 NaN 으로 두고, 호출자(피처 스토어)에서 결측치 처리한다.
+    """
+    if analysis_date is None:
+        analysis_date = get_analysis_date(events)
+    analysis_date = pd.Timestamp(analysis_date)
+
+    recent_start = analysis_date - pd.Timedelta(days=recent_days)
+    prior_start = recent_start - pd.Timedelta(days=prior_days)
+
+    recent_events = events[
+        (events["event_date"] >= recent_start) & (events["event_date"] < analysis_date)
+    ]
+    prior_events = events[
+        (events["event_date"] >= prior_start) & (events["event_date"] < recent_start)
+    ]
+
+    # 1. 방문 횟수 변화율 (방문 = page_view 이벤트가 하루에 1번 이상 → 그날을 방문일로)
+    visit_recent = _count_visit_days(recent_events).rename("visit_recent")
+    visit_prior = _count_visit_days(prior_events).rename("visit_prior")
+
+    # 2. 구매 주기 변화율
+    cycle_recent = _avg_cycle_in_window(recent_events).rename("cycle_recent")
+    cycle_prior = _avg_cycle_in_window(prior_events).rename("cycle_prior")
+
+    # 3. 세션 시간 (proxy = 일평균 이벤트 수) 변화율
+    session_recent = _avg_events_per_active_day(recent_events).rename("session_recent")
+    session_prior = _avg_events_per_active_day(prior_events).rename("session_prior")
+
+    # 4. 장바구니 전환율 변화 (cart→purchase)
+    cart_conv_recent = _cart_conversion_rate(recent_events).rename("cart_conv_recent")
+    cart_conv_prior = _cart_conversion_rate(prior_events).rename("cart_conv_prior")
+
+    # 5. 쿠폰 반응률 변화 (전체 이벤트 중 coupon_use 비율)
+    coupon_recent = _coupon_response_rate(recent_events).rename("coupon_recent")
+    coupon_prior = _coupon_response_rate(prior_events).rename("coupon_prior")
+
+    # 6. 전체 이벤트 수 변화율
+    total_recent = recent_events.groupby("customer_id").size().rename("total_recent")
+    total_prior = prior_events.groupby("customer_id").size().rename("total_prior")
+
+    df = customers[["customer_id"]].copy()
+    for s in [
+        visit_recent, visit_prior,
+        cycle_recent, cycle_prior,
+        session_recent, session_prior,
+        cart_conv_recent, cart_conv_prior,
+        coupon_recent, coupon_prior,
+        total_recent, total_prior,
+    ]:
+        df = df.merge(s, on="customer_id", how="left")
+
+    # 결측 충전
+    for col in ["visit_recent", "visit_prior", "total_recent", "total_prior"]:
+        df[col] = df[col].fillna(0).astype(float)
+
+    df["visit_change_rate"] = df["visit_recent"] / df["visit_prior"].replace(0, np.nan)
+    df["purchase_cycle_change_rate"] = df["cycle_recent"] / df["cycle_prior"].replace(0, np.nan)
+    df["session_duration_change_rate"] = df["session_recent"] / df["session_prior"].replace(0, np.nan)
+    df["cart_conversion_change"] = df["cart_conv_recent"] - df["cart_conv_prior"]
+    df["coupon_response_change"] = df["coupon_recent"] - df["coupon_prior"]
+    df["event_volume_change_rate"] = df["total_recent"] / df["total_prior"].replace(0, np.nan)
+
+    # 활동 급감 플래그 (방문이 절반 이하로 줄었을 때)
+    df["activity_decline_flag"] = (
+        (df["visit_change_rate"].notna()) & (df["visit_change_rate"] < 0.5)
+    ).astype(int)
+
+    output_cols = [
+        "customer_id",
+        "visit_change_rate",
+        "purchase_cycle_change_rate",
+        "session_duration_change_rate",
+        "cart_conversion_change",
+        "coupon_response_change",
+        "event_volume_change_rate",
+        "activity_decline_flag",
+    ]
+    return df[output_cols]
+
+
+def _count_visit_days(events_window: pd.DataFrame) -> pd.Series:
+    """윈도 내 고객별 방문일(unique date) 수."""
+    if events_window.empty:
+        return pd.Series(dtype=float, name="visit_count")
+    visit = events_window[events_window["event_type"] == "page_view"]
+    if visit.empty:
+        return pd.Series(dtype=float, name="visit_count")
+    return (
+        visit.groupby("customer_id")["event_date"]
+        .apply(lambda s: s.dt.date.nunique())
+        .astype(float)
+    )
+
+
+def _avg_cycle_in_window(events_window: pd.DataFrame) -> pd.Series:
+    """윈도 내 평균 구매 주기 (구매 2회 이상인 고객만)."""
+    if events_window.empty:
+        return pd.Series(dtype=float)
+    purchases = events_window[events_window["event_type"] == "purchase"]
+    if purchases.empty:
+        return pd.Series(dtype=float)
+
+    sorted_p = purchases.sort_values(["customer_id", "event_date"])
+    sorted_p["gap"] = (
+        sorted_p.groupby("customer_id")["event_date"].diff().dt.days
+    )
+    return (
+        sorted_p.dropna(subset=["gap"])
+        .groupby("customer_id")["gap"]
+        .mean()
+        .astype(float)
+    )
+
+
+def _avg_events_per_active_day(events_window: pd.DataFrame) -> pd.Series:
+    """활동일당 평균 이벤트 수 — 세션 길이 proxy.
+
+    실제 timestamp 가 일 단위라 분 단위 세션 시간을 정확히 못 잡으므로,
+    활동일에 발생한 이벤트 개수를 세션 강도의 대리값으로 사용한다.
+    """
+    if events_window.empty:
+        return pd.Series(dtype=float)
+    events_window = events_window.copy()
+    events_window["date"] = events_window["event_date"].dt.date
+    by_day = events_window.groupby(["customer_id", "date"]).size()
+    return by_day.groupby("customer_id").mean().astype(float)
+
+
+def _cart_conversion_rate(events_window: pd.DataFrame) -> pd.Series:
+    """장바구니 → 구매 전환율 = purchase 수 / add_to_cart 수.
+
+    add_to_cart 가 0인 고객은 NaN.
+    """
+    if events_window.empty:
+        return pd.Series(dtype=float)
+    cart = events_window[events_window["event_type"] == "add_to_cart"].groupby("customer_id").size()
+    purchase = events_window[events_window["event_type"] == "purchase"].groupby("customer_id").size()
+    df = pd.concat([cart.rename("cart"), purchase.rename("purchase")], axis=1).fillna(0)
+    rate = df["purchase"] / df["cart"].replace(0, np.nan)
+    return rate.astype(float)
+
+
+def _coupon_response_rate(events_window: pd.DataFrame) -> pd.Series:
+    """전체 이벤트 중 coupon_use 비율."""
+    if events_window.empty:
+        return pd.Series(dtype=float)
+    total = events_window.groupby("customer_id").size()
+    coupon = (
+        events_window[events_window["event_type"] == "coupon_use"]
+        .groupby("customer_id")
+        .size()
+    )
+    df = pd.concat([total.rename("total"), coupon.rename("coupon")], axis=1).fillna(0)
+    rate = df["coupon"] / df["total"].replace(0, np.nan)
+    return rate.astype(float)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline entry
+# ---------------------------------------------------------------------------
+
+def run_rfm_pipeline(
+    data_dir: str | Path = "data/raw",
+    output_dir: str | Path = "data/processed",
+) -> pd.DataFrame:
+    """RFM + 행동 변화율 피처를 모두 산출하고 CSV 로 저장한다.
+
+    Returns
+    -------
+    DataFrame  (customer_id 기준 left-join 결과)
+    """
+    data_dir = Path(data_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    customers, events = load_data(data_dir)
+    analysis_date = get_analysis_date(events)
+    print(f"[RFM] Analysis date: {analysis_date.date()}")
+    print(f"[RFM] Customers: {len(customers):,}  Events: {len(events):,}")
+
+    rfm = compute_rfm_features(customers, events, analysis_date)
+    change = compute_change_rate_features(customers, events, analysis_date)
+
+    out = customers[["customer_id"]].merge(rfm, on="customer_id", how="left")
+    out = out.merge(change, on="customer_id", how="left")
+
+    output_path = output_dir / "rfm_features.csv"
+    out.to_csv(output_path, index=False)
+    print(f"[RFM] Saved {len(out):,} rows × {out.shape[1]} cols → {output_path}")
+
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="RFM + behavioral change-rate features")
+    parser.add_argument("--data-dir", default="data/raw")
+    parser.add_argument("--output-dir", default="data/processed")
+    args = parser.parse_args()
+    run_rfm_pipeline(data_dir=args.data_dir, output_dir=args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/features/rfm.py
+++ b/src/features/rfm.py
@@ -446,6 +446,7 @@ def run_rfm_pipeline(
 
 
 def main() -> None:
+    """CLI entry point for RFM + behavioral change-rate feature computation."""
     parser = argparse.ArgumentParser(description="RFM + behavioral change-rate features")
     parser.add_argument("--data-dir", default="data/raw")
     parser.add_argument("--output-dir", default="data/processed")

--- a/src/features/sequence.py
+++ b/src/features/sequence.py
@@ -113,7 +113,7 @@ def compute_sequence_features(
     if events.empty:
         for col in [
             "seq_entropy", "seq_unique_event_types", "seq_transition_count",
-            "seq_dominant_event", "seq_purchase_position", "behavior_cluster_id",
+            "seq_purchase_position", "seq_dominant_event_id", "behavior_cluster_id",
         ]:
             base[col] = np.nan
         return base
@@ -158,7 +158,12 @@ def compute_sequence_features(
     base = base.merge(purch_pos, on="customer_id", how="left")
 
     # 6. 행동 패턴 클러스터 ID (전체 이벤트 분포 기반)
-    base["behavior_cluster_id"] = _behavior_cluster_ids(events, n_clusters=n_clusters)
+    # _behavior_cluster_ids 는 customer_id 를 인덱스로 가진 Series 를 반환하므로
+    # merge 로 customer_id 기준 정렬을 보장한다 (직접 할당 시 RangeIndex 와 어긋남).
+    cluster_ids = _behavior_cluster_ids(events, n_clusters=n_clusters).rename(
+        "behavior_cluster_id"
+    )
+    base = base.merge(cluster_ids, left_on="customer_id", right_index=True, how="left")
 
     # 카테고리형 → 정수 인코딩
     base["seq_dominant_event_id"] = base["seq_dominant_event"].map(

--- a/src/features/sequence.py
+++ b/src/features/sequence.py
@@ -1,0 +1,430 @@
+"""Sequence and customer-journey feature engineering — Task 3.4.
+
+시뮬레이터 출력을 입력으로 받아 시퀀스 피처와 고객 여정 단계 피처를 산출한다.
+
+명세서 요구사항
+---------------
+- 시퀀스 피처를 최소 2개 이상 설계
+  예: 최근 N개 이벤트 타입 시퀀스 임베딩, 행동 패턴 클러스터 ID
+- 고객 여정 단계 피처(현재 여정 단계, 단계별 체류 기간) 산출
+- 이탈 직전 주요 이벤트(장바구니 포기, CS 문의 등)의 빈도 분석
+
+설계 노트
+---------
+시퀀스 임베딩은 무거운 모델 없이도 의미 있는 피처를 만들 수 있도록
+- 최근 N개 이벤트 타입의 transition entropy
+- 최근 N개 이벤트 타입 바이그램의 주요 패턴 매칭
+- 행동 패턴 클러스터 ID는 KMeans 로 산출 (sklearn)
+하는 방식으로 구현한다. (DL 임베딩은 4.5에서 별도 진행)
+
+여정 단계는 명세서 정의(가입→첫구매→재구매→충성→이탈)를 따른다.
+    new        : 가입만, 구매 0
+    first_buy  : 첫 구매 완료, 재구매 X
+    repeat     : 재구매 완료(구매 ≥ 2), 충성 미달
+    loyal      : 구매 ≥ 5 또는 최근 30일 내 활동 + 구매 다수
+    churned    : customers.churned == 1
+
+Usage
+-----
+    python src/features/sequence.py
+    python src/features/sequence.py --data-dir data/raw --output-dir data/processed
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+# 시퀀스 길이: 최근 N개 이벤트
+SEQUENCE_LENGTH: int = 20
+
+# 행동 패턴 클러스터 개수
+N_BEHAVIOR_CLUSTERS: int = 5
+
+# 이탈 직전 패턴 분석 윈도 (일)
+PRE_CHURN_WINDOW_DAYS: int = 30
+
+# 충성 단계 판정 기준
+LOYAL_PURCHASE_THRESHOLD: int = 5
+
+# 사전 정의된 이벤트 타입 (vocab)
+EVENT_VOCAB: tuple[str, ...] = (
+    "page_view",
+    "search",
+    "add_to_cart",
+    "remove_from_cart",
+    "purchase",
+    "coupon_use",
+    "review",
+    "cs_contact",
+)
+
+
+# ---------------------------------------------------------------------------
+# I/O
+# ---------------------------------------------------------------------------
+
+def load_data(data_dir: str | Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    data_dir = Path(data_dir)
+    customers = pd.read_csv(data_dir / "customers.csv")
+    events = pd.read_csv(data_dir / "events.csv")
+    customers["signup_date"] = pd.to_datetime(customers["signup_date"], errors="coerce")
+    events["event_date"] = pd.to_datetime(events["event_date"], errors="coerce")
+    events = events.dropna(subset=["event_date"]).copy()
+    return customers, events
+
+
+def get_analysis_date(events: pd.DataFrame) -> pd.Timestamp:
+    return events["event_date"].max() + pd.Timedelta(days=1)
+
+
+# ---------------------------------------------------------------------------
+# Sequence features (2+)
+# ---------------------------------------------------------------------------
+
+def compute_sequence_features(
+    customers: pd.DataFrame,
+    events: pd.DataFrame,
+    seq_length: int = SEQUENCE_LENGTH,
+    n_clusters: int = N_BEHAVIOR_CLUSTERS,
+) -> pd.DataFrame:
+    """시퀀스 피처 산출.
+
+    산출 컬럼
+    ---------
+    seq_entropy              : 최근 N개 이벤트 타입 분포의 Shannon entropy
+                               (낮을수록 행동이 단조 → 이탈 위험 신호)
+    seq_unique_event_types   : 최근 N개 이벤트 내 unique 이벤트 타입 수
+    seq_transition_count     : 최근 N개 이벤트에서 직전 이벤트와 다른 타입으로 바뀐 횟수
+                               (행동 다양성 proxy)
+    seq_dominant_event       : 최근 N개 중 가장 많은 이벤트 타입 (카테고리 인코딩)
+    seq_purchase_position    : 최근 N개 중 마지막 purchase 의 (뒤에서 본) 위치 인덱스
+                               (작을수록 최근 구매 ↔ 클수록 오래전)
+    behavior_cluster_id      : 이벤트 타입 분포 기반 KMeans 클러스터 ID
+
+    분모/길이가 0인 경우(이벤트 없음) NaN 으로 두고 store.py 에서 처리.
+    """
+    base = customers[["customer_id"]].copy()
+
+    if events.empty:
+        for col in [
+            "seq_entropy", "seq_unique_event_types", "seq_transition_count",
+            "seq_dominant_event", "seq_purchase_position", "behavior_cluster_id",
+        ]:
+            base[col] = np.nan
+        return base
+
+    # 고객별로 가장 최근 N개 이벤트 추출
+    sorted_ev = events.sort_values(["customer_id", "event_date"])
+    sorted_ev["rank_desc"] = (
+        sorted_ev.groupby("customer_id").cumcount(ascending=False)
+    )
+    recent = sorted_ev[sorted_ev["rank_desc"] < seq_length].copy()
+    recent = recent.sort_values(["customer_id", "event_date"])
+
+    # 1. 엔트로피
+    entropy_series = (
+        recent.groupby("customer_id")["event_type"].apply(_event_entropy).rename("seq_entropy")
+    )
+    # 2. unique 타입 수
+    unique_series = (
+        recent.groupby("customer_id")["event_type"].nunique().rename("seq_unique_event_types")
+    )
+    # 3. transition count
+    trans_series = (
+        recent.groupby("customer_id")["event_type"].apply(_count_transitions).rename("seq_transition_count")
+    )
+    # 4. dominant event
+    dom_series = (
+        recent.groupby("customer_id")["event_type"]
+        .agg(lambda s: s.value_counts().idxmax())
+        .rename("seq_dominant_event")
+    )
+    # 5. purchase position (뒤에서)
+    purch_pos = (
+        recent.groupby("customer_id")
+        .apply(_last_purchase_position)
+        .rename("seq_purchase_position")
+    )
+
+    base = base.merge(entropy_series, on="customer_id", how="left")
+    base = base.merge(unique_series, on="customer_id", how="left")
+    base = base.merge(trans_series, on="customer_id", how="left")
+    base = base.merge(dom_series, on="customer_id", how="left")
+    base = base.merge(purch_pos, on="customer_id", how="left")
+
+    # 6. 행동 패턴 클러스터 ID (전체 이벤트 분포 기반)
+    base["behavior_cluster_id"] = _behavior_cluster_ids(events, n_clusters=n_clusters)
+
+    # 카테고리형 → 정수 인코딩
+    base["seq_dominant_event_id"] = base["seq_dominant_event"].map(
+        {ev: i for i, ev in enumerate(EVENT_VOCAB)}
+    )
+    base = base.drop(columns=["seq_dominant_event"])
+
+    output_cols = [
+        "customer_id",
+        "seq_entropy",
+        "seq_unique_event_types",
+        "seq_transition_count",
+        "seq_purchase_position",
+        "seq_dominant_event_id",
+        "behavior_cluster_id",
+    ]
+    return base[output_cols]
+
+
+def _event_entropy(s: pd.Series) -> float:
+    """Shannon entropy of event-type distribution (in nats)."""
+    if len(s) == 0:
+        return np.nan
+    counts = s.value_counts(normalize=True).to_numpy()
+    counts = counts[counts > 0]
+    return float(-np.sum(counts * np.log(counts)))
+
+
+def _count_transitions(s: pd.Series) -> int:
+    """직전 이벤트와 타입이 다르면 1 (=상태 변화 횟수)."""
+    if len(s) <= 1:
+        return 0
+    arr = s.to_numpy()
+    return int((arr[1:] != arr[:-1]).sum())
+
+
+def _last_purchase_position(grp: pd.DataFrame) -> float:
+    """뒤에서부터 본 마지막 purchase 의 위치 (0=가장 최근).
+
+    구매가 없으면 NaN 반환.
+    """
+    types = grp["event_type"].to_numpy()
+    n = len(types)
+    for i, t in enumerate(types[::-1]):
+        if t == "purchase":
+            return float(i)
+    return float("nan")
+
+
+def _behavior_cluster_ids(events: pd.DataFrame, n_clusters: int) -> pd.Series:
+    """전체 이벤트 분포 기반 KMeans 클러스터 ID.
+
+    sklearn 사용. KMeans 가 import 안 되거나 표본이 너무 적으면 모두 0.
+    """
+    try:
+        from sklearn.cluster import KMeans
+    except ImportError:
+        return pd.Series([0] * events["customer_id"].nunique(), index=events["customer_id"].unique())
+
+    # 고객 × 이벤트타입 비율 매트릭스
+    pivot = (
+        events.groupby(["customer_id", "event_type"])
+        .size()
+        .unstack("event_type", fill_value=0)
+    )
+    # 누락 컬럼 채우기 (vocab 정렬)
+    for ev in EVENT_VOCAB:
+        if ev not in pivot.columns:
+            pivot[ev] = 0
+    pivot = pivot[list(EVENT_VOCAB)]
+
+    # 정규화 (행 합이 0인 경우는 그대로 0)
+    row_sums = pivot.sum(axis=1).replace(0, 1)
+    norm = pivot.div(row_sums, axis=0)
+
+    n_eff = min(n_clusters, len(norm))
+    if n_eff < 2:
+        return pd.Series([0] * len(norm), index=norm.index)
+
+    km = KMeans(n_clusters=n_eff, random_state=42, n_init=10)
+    labels = km.fit_predict(norm.to_numpy())
+    return pd.Series(labels, index=norm.index, name="behavior_cluster_id").astype(int)
+
+
+# ---------------------------------------------------------------------------
+# Customer journey stage features
+# ---------------------------------------------------------------------------
+
+# 단계 → ID 매핑
+JOURNEY_STAGE_ID: dict[str, int] = {
+    "new": 0,
+    "first_buy": 1,
+    "repeat": 2,
+    "loyal": 3,
+    "churned": 4,
+}
+
+
+def compute_journey_features(
+    customers: pd.DataFrame,
+    events: pd.DataFrame,
+    analysis_date: pd.Timestamp | None = None,
+) -> pd.DataFrame:
+    """고객 여정 단계 피처 산출.
+
+    산출 컬럼
+    ---------
+    journey_stage              : new | first_buy | repeat | loyal | churned
+    journey_stage_id           : 0~4 정수
+    days_in_current_stage      : 현재 단계에 진입한 후 경과 일수
+    purchase_count             : 총 구매 횟수
+    days_since_signup          : 가입 후 경과 일수
+    cart_abandon_count_recent  : 최근 30일 내 remove_from_cart 빈도 (이탈 직전 패턴)
+    cs_contact_count_recent    : 최근 30일 내 cs_contact 빈도 (이탈 직전 패턴)
+    """
+    if analysis_date is None:
+        analysis_date = get_analysis_date(events)
+    analysis_date = pd.Timestamp(analysis_date)
+
+    base = customers[["customer_id", "signup_date", "churned"]].copy()
+    base["days_since_signup"] = (analysis_date - base["signup_date"]).dt.days
+
+    # 구매 관련
+    purch = events[events["event_type"] == "purchase"].copy()
+    purch_count = purch.groupby("customer_id").size().rename("purchase_count")
+    first_purch = purch.groupby("customer_id")["event_date"].min().rename("first_purchase_date")
+
+    # n번째 구매일을 안전하게 추출 (pandas 버전별 nth 동작 차이 회피)
+    purch_sorted = purch.sort_values(["customer_id", "event_date"])
+    purch_sorted["rank"] = purch_sorted.groupby("customer_id").cumcount()
+    second_purch = (
+        purch_sorted[purch_sorted["rank"] == 1]
+        .set_index("customer_id")["event_date"]
+        .rename("second_purchase_date")
+    )
+    fifth_purch = (
+        purch_sorted[purch_sorted["rank"] == (LOYAL_PURCHASE_THRESHOLD - 1)]
+        .set_index("customer_id")["event_date"]
+        .rename("loyal_entry_date")
+    )
+
+    base = base.merge(purch_count, on="customer_id", how="left")
+    base = base.merge(first_purch, on="customer_id", how="left")
+    base = base.merge(second_purch, on="customer_id", how="left")
+    base = base.merge(fifth_purch, on="customer_id", how="left")
+    base["purchase_count"] = base["purchase_count"].fillna(0).astype(int)
+
+    # 단계 결정
+    base["journey_stage"] = base.apply(_classify_stage, axis=1)
+    base["journey_stage_id"] = base["journey_stage"].map(JOURNEY_STAGE_ID).astype(float)
+
+    # 단계별 진입일 → 체류 기간
+    base["stage_entry_date"] = base.apply(_stage_entry_date, axis=1)
+    base["days_in_current_stage"] = (
+        analysis_date - base["stage_entry_date"]
+    ).dt.days.astype("Int64").astype(float)
+
+    # 이탈 직전 패턴 빈도 (분석 기준일 기준 최근 30일)
+    pre_window_start = analysis_date - pd.Timedelta(days=PRE_CHURN_WINDOW_DAYS)
+    pre = events[
+        (events["event_date"] >= pre_window_start) & (events["event_date"] < analysis_date)
+    ]
+    cart_abandon = (
+        pre[pre["event_type"] == "remove_from_cart"]
+        .groupby("customer_id")
+        .size()
+        .rename("cart_abandon_count_recent")
+    )
+    cs_contact = (
+        pre[pre["event_type"] == "cs_contact"]
+        .groupby("customer_id")
+        .size()
+        .rename("cs_contact_count_recent")
+    )
+    base = base.merge(cart_abandon, on="customer_id", how="left")
+    base = base.merge(cs_contact, on="customer_id", how="left")
+    base["cart_abandon_count_recent"] = base["cart_abandon_count_recent"].fillna(0).astype(float)
+    base["cs_contact_count_recent"] = base["cs_contact_count_recent"].fillna(0).astype(float)
+
+    output_cols = [
+        "customer_id",
+        "journey_stage",
+        "journey_stage_id",
+        "days_in_current_stage",
+        "purchase_count",
+        "days_since_signup",
+        "cart_abandon_count_recent",
+        "cs_contact_count_recent",
+    ]
+    return base[output_cols]
+
+
+def _classify_stage(row: pd.Series) -> str:
+    if int(row["churned"]) == 1:
+        return "churned"
+    pc = int(row["purchase_count"])
+    if pc == 0:
+        return "new"
+    if pc >= LOYAL_PURCHASE_THRESHOLD:
+        return "loyal"
+    if pc == 1:
+        return "first_buy"
+    return "repeat"
+
+
+def _stage_entry_date(row: pd.Series) -> pd.Timestamp:
+    """현재 단계에 진입한 날짜.
+
+    new       → signup_date
+    first_buy → first_purchase_date
+    repeat    → second_purchase_date
+    loyal     → loyal_entry_date (5번째 구매일)
+    churned   → 마지막 활동일 추정 어려우므로 first_purchase_date or signup_date 로 근사
+    """
+    stage = row["journey_stage"]
+    if stage == "new":
+        return row["signup_date"]
+    if stage == "first_buy":
+        return row.get("first_purchase_date", row["signup_date"])
+    if stage == "repeat":
+        return row.get("second_purchase_date", row.get("first_purchase_date", row["signup_date"]))
+    if stage == "loyal":
+        return row.get("loyal_entry_date", row.get("first_purchase_date", row["signup_date"]))
+    # churned: 사용 가능한 가장 최근 단계 진입일
+    for col in ["loyal_entry_date", "second_purchase_date", "first_purchase_date"]:
+        if col in row and pd.notna(row[col]):
+            return row[col]
+    return row["signup_date"]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline entry
+# ---------------------------------------------------------------------------
+
+def run_sequence_pipeline(
+    data_dir: str | Path = "data/raw",
+    output_dir: str | Path = "data/processed",
+) -> pd.DataFrame:
+    data_dir = Path(data_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    customers, events = load_data(data_dir)
+    analysis_date = get_analysis_date(events)
+    print(f"[Sequence] Customers: {len(customers):,}  Events: {len(events):,}")
+    print(f"[Sequence] Analysis date: {analysis_date.date()}")
+
+    seq = compute_sequence_features(customers, events)
+    journey = compute_journey_features(customers, events, analysis_date)
+
+    out = seq.merge(journey, on="customer_id", how="left")
+
+    output_path = output_dir / "sequence_features.csv"
+    out.to_csv(output_path, index=False)
+    print(f"[Sequence] Saved {len(out):,} rows × {out.shape[1]} cols → {output_path}")
+
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sequence + journey features")
+    parser.add_argument("--data-dir", default="data/raw")
+    parser.add_argument("--output-dir", default="data/processed")
+    args = parser.parse_args()
+    run_sequence_pipeline(data_dir=args.data_dir, output_dir=args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/features/sequence.py
+++ b/src/features/sequence.py
@@ -69,6 +69,10 @@ EVENT_VOCAB: tuple[str, ...] = (
 # ---------------------------------------------------------------------------
 
 def load_data(data_dir: str | Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Load simulator outputs and parse date columns.
+
+    Returns (customers, events) with parsed signup_date / event_date.
+    """
     data_dir = Path(data_dir)
     customers = pd.read_csv(data_dir / "customers.csv")
     events = pd.read_csv(data_dir / "events.csv")
@@ -79,6 +83,7 @@ def load_data(data_dir: str | Path) -> tuple[pd.DataFrame, pd.DataFrame]:
 
 
 def get_analysis_date(events: pd.DataFrame) -> pd.Timestamp:
+    """분석 기준일 = 마지막 이벤트 다음날 (cohort.py / eda.ipynb 와 동일 규칙)."""
     return events["event_date"].max() + pd.Timedelta(days=1)
 
 
@@ -357,6 +362,7 @@ def compute_journey_features(
 
 
 def _classify_stage(row: pd.Series) -> str:
+    """고객 한 명을 여정 단계로 분류한다 (new/first_buy/repeat/loyal/churned)."""
     if int(row["churned"]) == 1:
         return "churned"
     pc = int(row["purchase_count"])
@@ -402,6 +408,7 @@ def run_sequence_pipeline(
     data_dir: str | Path = "data/raw",
     output_dir: str | Path = "data/processed",
 ) -> pd.DataFrame:
+    """시퀀스 + 여정 피처를 산출하고 CSV 로 저장한다."""
     data_dir = Path(data_dir)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -424,6 +431,7 @@ def run_sequence_pipeline(
 
 
 def main() -> None:
+    """CLI entry point for sequence + journey feature computation."""
     parser = argparse.ArgumentParser(description="Sequence + journey features")
     parser.add_argument("--data-dir", default="data/raw")
     parser.add_argument("--output-dir", default="data/processed")

--- a/src/features/session.py
+++ b/src/features/session.py
@@ -159,8 +159,13 @@ def _search_to_purchase_rate(
         # 검색이 아예 없으면 전부 NaN
         return pd.Series(dtype=float)
 
-    # 검색이 있는 고객에 한해서만 계산
+    # 검색이 있는 고객에 한해서만 계산. 같은 날 여러 검색이 있을 수 있으므로
+    # 각 검색 이벤트를 별개로 카운트하기 위해 search_id 를 부여한다.
     purchases = purchases.rename(columns={"event_date": "purchase_date"})
+
+    searches = searches.reset_index(drop=True).reset_index().rename(
+        columns={"index": "search_id"}
+    )
 
     joined = searches.merge(purchases, on="customer_id", how="left")
     joined["gap_days"] = (joined["purchase_date"] - joined["event_date"]).dt.days
@@ -168,9 +173,14 @@ def _search_to_purchase_rate(
         (joined["gap_days"] >= 0) & (joined["gap_days"] <= window_days)
     ).astype(int)
 
-    # 한 검색당 적어도 1번 전환되면 1, 아니면 0
-    per_search = joined.groupby(["customer_id", "event_date"])["converted"].max()
-    rate = per_search.groupby(level=0).mean()
+    # 각 검색 이벤트별로 윈도 내 구매 1건 이상이면 1
+    per_search = joined.groupby("search_id")["converted"].max()
+    # 고객별 평균 = 그 고객의 검색 중 전환된 비율
+    rate = (
+        searches.assign(converted=searches["search_id"].map(per_search).fillna(0))
+        .groupby("customer_id")["converted"]
+        .mean()
+    )
     return rate.astype(float)
 
 

--- a/src/features/session.py
+++ b/src/features/session.py
@@ -1,0 +1,312 @@
+"""Session-quality and time-based feature engineering — Task 3.3.
+
+시뮬레이터 출력을 입력으로 받아 세션 품질 피처와 시간대별 행동 피처를 산출한다.
+
+명세서 요구사항
+---------------
+- 세션 품질 피처(평균 세션 시간, 페이지뷰/세션, 검색 후 구매 전환율) 최소 3개 이상
+- 시간대별 행동 피처(주말/평일 구매 비율, 특정 시간대 활동 비율)
+
+설계 노트
+---------
+시뮬레이터의 event_date 는 일 단위 정밀도(시각 정보 없음)이므로
+"세션"을 다음과 같이 정의한다:
+    세션 = 같은 고객의 같은 날짜에 발생한 이벤트들의 묶음
+    세션 길이(=세션 시간 proxy) = 해당 세션의 이벤트 개수
+
+시간대 피처(요일/주말)는 event_date 의 dayofweek 로 산출 가능하다.
+"특정 시간대 활동 비율"은 시각 정보가 없는 한계로
+"월초/월말" 활동 비율로 대체한다 (이탈 직전 패턴 분석에 유용한 대체 신호).
+
+Simulator output schema
+-----------------------
+events.csv : customer_id, event_date, event_type, persona, is_treatment, order_value
+
+Usage
+-----
+    python src/features/session.py
+    python src/features/session.py --data-dir data/raw --output-dir data/processed
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+# 검색→구매 전환을 판정할 시간 윈도 (일).
+# event_date 가 일 단위이므로 같은 날 또는 N일 이내 동일 고객의 구매는 "검색 후 구매"로 간주.
+SEARCH_TO_PURCHASE_WINDOW_DAYS: int = 7
+
+
+# ---------------------------------------------------------------------------
+# I/O
+# ---------------------------------------------------------------------------
+
+def load_data(data_dir: str | Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    data_dir = Path(data_dir)
+    customers = pd.read_csv(data_dir / "customers.csv")
+    events = pd.read_csv(data_dir / "events.csv")
+    customers["signup_date"] = pd.to_datetime(customers["signup_date"], errors="coerce")
+    events["event_date"] = pd.to_datetime(events["event_date"], errors="coerce")
+    events = events.dropna(subset=["event_date"]).copy()
+    return customers, events
+
+
+# ---------------------------------------------------------------------------
+# Session-quality features (3+)
+# ---------------------------------------------------------------------------
+
+def compute_session_features(
+    customers: pd.DataFrame,
+    events: pd.DataFrame,
+) -> pd.DataFrame:
+    """세션 품질 피처 산출 (3개 이상).
+
+    산출 컬럼
+    ---------
+    avg_session_length         : 평균 세션 시간 proxy (이벤트 수/세션)
+    avg_pageviews_per_session  : 세션당 평균 page_view 수
+    search_to_purchase_rate    : 검색 후 N일 내 구매 전환율
+    total_sessions             : 활동한 날짜 수 (세션 수)
+    bounce_rate                : 이벤트 1개로 끝난 세션 비율 (이탈로의 신호)
+    avg_event_diversity        : 세션당 평균 unique 이벤트 타입 수
+
+    분모가 0인 경우 NaN 으로 두고 store.py 에서 결측 처리한다.
+    """
+    base = customers[["customer_id"]].copy()
+
+    # 같은 (customer_id, date) 가 한 세션
+    ev = events.copy()
+    ev["date"] = ev["event_date"].dt.date
+
+    # 세션별 메트릭 계산
+    session_grp = ev.groupby(["customer_id", "date"])
+
+    session_size = session_grp.size().rename("event_count")
+    session_pv = (
+        ev[ev["event_type"] == "page_view"]
+        .groupby(["customer_id", "date"])
+        .size()
+        .rename("pv_count")
+    )
+    session_diversity = session_grp["event_type"].nunique().rename("type_count")
+
+    session_df = pd.concat([session_size, session_pv, session_diversity], axis=1).fillna(
+        {"pv_count": 0}
+    )
+
+    # 고객별 집계
+    by_cust = (
+        session_df.groupby(level=0)
+        .agg(
+            avg_session_length=("event_count", "mean"),
+            avg_pageviews_per_session=("pv_count", "mean"),
+            total_sessions=("event_count", "size"),
+            avg_event_diversity=("type_count", "mean"),
+        )
+    )
+
+    # bounce: 이벤트 1개짜리 세션 비율
+    bounce = (
+        session_df.groupby(level=0)["event_count"]
+        .apply(lambda s: float((s == 1).mean()))
+        .rename("bounce_rate")
+    )
+    by_cust = by_cust.join(bounce)
+
+    base = base.merge(by_cust, left_on="customer_id", right_index=True, how="left")
+
+    # 검색 → 구매 전환율
+    s2p = _search_to_purchase_rate(events, window_days=SEARCH_TO_PURCHASE_WINDOW_DAYS)
+    base = base.merge(s2p.rename("search_to_purchase_rate"), on="customer_id", how="left")
+
+    output_cols = [
+        "customer_id",
+        "avg_session_length",
+        "avg_pageviews_per_session",
+        "search_to_purchase_rate",
+        "total_sessions",
+        "bounce_rate",
+        "avg_event_diversity",
+    ]
+    return base[output_cols]
+
+
+def _search_to_purchase_rate(
+    events: pd.DataFrame,
+    window_days: int = SEARCH_TO_PURCHASE_WINDOW_DAYS,
+) -> pd.Series:
+    """검색 후 N일 내 구매가 일어난 비율 = 전환된 검색 수 / 전체 검색 수.
+
+    같은 고객 안에서, 각 search 이벤트로부터 window_days 일 이내에
+    purchase 이벤트가 1건이라도 있으면 그 검색은 전환된 것으로 본다.
+    """
+    if events.empty:
+        return pd.Series(dtype=float)
+
+    searches = events[events["event_type"] == "search"][
+        ["customer_id", "event_date"]
+    ].copy()
+    purchases = events[events["event_type"] == "purchase"][
+        ["customer_id", "event_date"]
+    ].copy()
+
+    if searches.empty:
+        # 검색이 아예 없으면 전부 NaN
+        return pd.Series(dtype=float)
+
+    # 검색이 있는 고객에 한해서만 계산
+    purchases = purchases.rename(columns={"event_date": "purchase_date"})
+
+    joined = searches.merge(purchases, on="customer_id", how="left")
+    joined["gap_days"] = (joined["purchase_date"] - joined["event_date"]).dt.days
+    joined["converted"] = (
+        (joined["gap_days"] >= 0) & (joined["gap_days"] <= window_days)
+    ).astype(int)
+
+    # 한 검색당 적어도 1번 전환되면 1, 아니면 0
+    per_search = joined.groupby(["customer_id", "event_date"])["converted"].max()
+    rate = per_search.groupby(level=0).mean()
+    return rate.astype(float)
+
+
+# ---------------------------------------------------------------------------
+# Time-based features
+# ---------------------------------------------------------------------------
+
+def compute_time_features(
+    customers: pd.DataFrame,
+    events: pd.DataFrame,
+) -> pd.DataFrame:
+    """시간대별 행동 피처를 산출한다.
+
+    산출 컬럼
+    ---------
+    weekend_purchase_ratio   : 주말 구매 비율 (전체 구매 중 토/일 비율)
+    weekend_visit_ratio      : 주말 방문(=page_view) 비율
+    weekday_event_ratio      : 평일 이벤트 비율 (월~금)
+    month_end_activity_ratio : 월말(25일 이후) 활동 비율 (proxy of "특정 시간대")
+    month_start_activity_ratio : 월초(1~7일) 활동 비율
+    active_day_span          : 첫 ~ 마지막 이벤트일 사이 일 수
+    active_day_ratio         : 활동일 수 / active_day_span (활동 밀도)
+    """
+    base = customers[["customer_id"]].copy()
+
+    if events.empty:
+        for col in [
+            "weekend_purchase_ratio",
+            "weekend_visit_ratio",
+            "weekday_event_ratio",
+            "month_end_activity_ratio",
+            "month_start_activity_ratio",
+            "active_day_span",
+            "active_day_ratio",
+        ]:
+            base[col] = np.nan
+        return base
+
+    ev = events.copy()
+    ev["dow"] = ev["event_date"].dt.dayofweek      # 0=월, 6=일
+    ev["dom"] = ev["event_date"].dt.day            # day of month
+    ev["is_weekend"] = ev["dow"].isin([5, 6]).astype(int)
+    ev["is_month_end"] = (ev["dom"] >= 25).astype(int)
+    ev["is_month_start"] = (ev["dom"] <= 7).astype(int)
+
+    # ---- 주말/평일 비율 ----
+    purchase_ev = ev[ev["event_type"] == "purchase"]
+    visit_ev = ev[ev["event_type"] == "page_view"]
+
+    weekend_purchase = (
+        purchase_ev.groupby("customer_id")["is_weekend"].mean().rename("weekend_purchase_ratio")
+    )
+    weekend_visit = (
+        visit_ev.groupby("customer_id")["is_weekend"].mean().rename("weekend_visit_ratio")
+    )
+    weekday_event = (
+        ev.groupby("customer_id")["is_weekend"]
+        .apply(lambda s: 1.0 - s.mean())
+        .rename("weekday_event_ratio")
+    )
+
+    # ---- 월말/월초 활동 비율 ----
+    month_end = (
+        ev.groupby("customer_id")["is_month_end"].mean().rename("month_end_activity_ratio")
+    )
+    month_start = (
+        ev.groupby("customer_id")["is_month_start"].mean().rename("month_start_activity_ratio")
+    )
+
+    # ---- 활동 일수 / 활동 기간 ----
+    active_days = (
+        ev.groupby("customer_id")["event_date"]
+        .apply(lambda s: s.dt.normalize().nunique())
+        .rename("active_days_count")
+    )
+    span = (
+        ev.groupby("customer_id")["event_date"]
+        .agg(lambda s: (s.max() - s.min()).days + 1)
+        .rename("active_day_span")
+    )
+    ratio = (active_days / span.replace(0, np.nan)).rename("active_day_ratio")
+
+    for s in [
+        weekend_purchase, weekend_visit, weekday_event,
+        month_end, month_start, span, ratio,
+    ]:
+        base = base.merge(s, on="customer_id", how="left")
+
+    output_cols = [
+        "customer_id",
+        "weekend_purchase_ratio",
+        "weekend_visit_ratio",
+        "weekday_event_ratio",
+        "month_end_activity_ratio",
+        "month_start_activity_ratio",
+        "active_day_span",
+        "active_day_ratio",
+    ]
+    return base[output_cols]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline entry
+# ---------------------------------------------------------------------------
+
+def run_session_pipeline(
+    data_dir: str | Path = "data/raw",
+    output_dir: str | Path = "data/processed",
+) -> pd.DataFrame:
+    """세션 + 시간대 피처를 산출하고 CSV로 저장."""
+    data_dir = Path(data_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    customers, events = load_data(data_dir)
+    print(f"[Session] Customers: {len(customers):,}  Events: {len(events):,}")
+
+    sess = compute_session_features(customers, events)
+    time_ = compute_time_features(customers, events)
+
+    out = sess.merge(time_, on="customer_id", how="left")
+
+    output_path = output_dir / "session_features.csv"
+    out.to_csv(output_path, index=False)
+    print(f"[Session] Saved {len(out):,} rows × {out.shape[1]} cols → {output_path}")
+
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Session + time-based features")
+    parser.add_argument("--data-dir", default="data/raw")
+    parser.add_argument("--output-dir", default="data/processed")
+    args = parser.parse_args()
+    run_session_pipeline(data_dir=args.data_dir, output_dir=args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/features/session.py
+++ b/src/features/session.py
@@ -47,6 +47,10 @@ SEARCH_TO_PURCHASE_WINDOW_DAYS: int = 7
 # ---------------------------------------------------------------------------
 
 def load_data(data_dir: str | Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Load simulator outputs and parse date columns.
+
+    Returns (customers, events) with parsed signup_date / event_date.
+    """
     data_dir = Path(data_dir)
     customers = pd.read_csv(data_dir / "customers.csv")
     events = pd.read_csv(data_dir / "events.csv")
@@ -311,6 +315,7 @@ def run_session_pipeline(
 
 
 def main() -> None:
+    """CLI entry point for session + time-based feature computation."""
     parser = argparse.ArgumentParser(description="Session + time-based features")
     parser.add_argument("--data-dir", default="data/raw")
     parser.add_argument("--output-dir", default="data/processed")

--- a/src/features/store.py
+++ b/src/features/store.py
@@ -308,15 +308,27 @@ def build_feature_store(
 
     print(f"[Store] Combined shape: {fs.shape}")
 
-    # 3. 결측 처리
+    # 3. 결측 처리 (사전에 ±inf 도 NaN 으로 통일)
+    fs = fs.replace([np.inf, -np.inf], np.nan)
     fs, missing_report = handle_missing_values(fs)
     print(f"[Store] Missing handled: {len(missing_report)} columns had NaNs")
 
-    # 4. 이상치 처리
+    # 4. 이상치 처리 (winsorization 과정에서 ±inf → NaN 변환이 한 번 더 일어날 수 있음)
     fs, outlier_report = handle_outliers(fs)
     print(f"[Store] Outliers winsorized: {len(outlier_report)} columns clipped")
 
-    # 5. 저장
+    # 5. 안전망: 이상치 처리 후 잔존 NaN 이 있으면 한 번 더 충전
+    residual_nan_cols = fs.columns[fs.isna().any()].tolist()
+    if residual_nan_cols:
+        fs, residual_report = handle_missing_values(fs)
+        print(
+            f"[Store] Residual NaNs after outlier handling: filled {len(residual_report)} columns"
+        )
+        # missing_report 에 잔존 처리 내역 병합
+        for col, info in residual_report.items():
+            missing_report[f"{col}__post_outlier"] = info
+
+    # 6. 저장
     if save:
         meta = {
             "analysis_date": str(analysis_date.date()),

--- a/src/features/store.py
+++ b/src/features/store.py
@@ -1,0 +1,384 @@
+"""Feature store: missing/outlier handling and integrated feature pipeline — Task 3.5.
+
+rfm.py / session.py / sequence.py 가 산출한 피처들을 모두 모아
+결측치 처리 / 이상치 처리 / 표준화된 피처 스토어로 저장한다.
+
+명세서 요구사항
+---------------
+- 모든 피처에 대해 결측치 처리와 이상치 처리 로직을 구현해야 한다.
+- 피처 산출 결과를 피처 스토어(Redis 또는 파일 기반)에 저장해야 한다.
+
+저장 형식
+---------
+- data/processed/feature_store.parquet : 빠른 재로드용 (pyarrow 필요)
+- data/processed/feature_store.csv     : 검토 / 디버깅용
+- data/processed/feature_store_meta.json : 피처별 결측/이상치 처리 통계
+
+Usage
+-----
+    python src/features/store.py
+    python src/features/store.py --data-dir data/raw --output-dir data/processed
+
+    # 모듈로
+    from features.store import build_feature_store, load_feature_store
+    fs = build_feature_store("data/raw", "data/processed")
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+# 같은 패키지의 모듈을 import. 패키지로 실행되든 직접 실행되든 둘 다 동작.
+try:
+    from features.rfm import compute_rfm_features, compute_change_rate_features, get_analysis_date
+    from features.session import compute_session_features, compute_time_features
+    from features.sequence import compute_sequence_features, compute_journey_features
+except ImportError:  # 직접 실행 (python src/features/store.py)
+    import sys
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from features.rfm import compute_rfm_features, compute_change_rate_features, get_analysis_date
+    from features.session import compute_session_features, compute_time_features
+    from features.sequence import compute_sequence_features, compute_journey_features
+
+
+# 이상치 처리: 분위수 기반 winsorization 의 상하한 분위
+WINSOR_LOW: float = 0.01
+WINSOR_HIGH: float = 0.99
+
+# 0/0 결과(inf)와 매우 큰 값에 대한 cap 임계
+INF_REPLACEMENT: float = np.nan
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+def _load_raw(data_dir: str | Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    data_dir = Path(data_dir)
+    customers = pd.read_csv(data_dir / "customers.csv")
+    events = pd.read_csv(data_dir / "events.csv")
+    customers["signup_date"] = pd.to_datetime(customers["signup_date"], errors="coerce")
+    events["event_date"] = pd.to_datetime(events["event_date"], errors="coerce")
+    events = events.dropna(subset=["event_date"]).copy()
+    return customers, events
+
+
+# ---------------------------------------------------------------------------
+# Missing-value handling
+# ---------------------------------------------------------------------------
+
+# 결측 시 사용할 기본 충전값 (의미가 명확한 피처별 규칙)
+MISSING_FILL_VALUES: dict[str, Any] = {
+    # RFM
+    "frequency": 0,
+    "monetary": 0.0,
+    "avg_order_value": 0.0,
+    "avg_purchase_cycle_days": -1.0,           # 단일/0회 구매 → 미정의
+    "purchase_cycle_anomaly": -1.0,            # 평균 주기 미정의 시
+    # 변화율 (분모 0 → NaN) → 1.0 (변화 없음) 으로 채움
+    "visit_change_rate": 1.0,
+    "purchase_cycle_change_rate": 1.0,
+    "session_duration_change_rate": 1.0,
+    "event_volume_change_rate": 1.0,
+    "cart_conversion_change": 0.0,
+    "coupon_response_change": 0.0,
+    "activity_decline_flag": 0,
+    # 세션
+    "avg_session_length": 0.0,
+    "avg_pageviews_per_session": 0.0,
+    "search_to_purchase_rate": 0.0,
+    "total_sessions": 0,
+    "bounce_rate": 0.0,
+    "avg_event_diversity": 0.0,
+    # 시간
+    "weekend_purchase_ratio": 0.0,
+    "weekend_visit_ratio": 0.0,
+    "weekday_event_ratio": 0.0,
+    "month_end_activity_ratio": 0.0,
+    "month_start_activity_ratio": 0.0,
+    "active_day_span": 0,
+    "active_day_ratio": 0.0,
+    # 시퀀스
+    "seq_entropy": 0.0,
+    "seq_unique_event_types": 0,
+    "seq_transition_count": 0,
+    "seq_purchase_position": -1.0,             # 구매 없음
+    "seq_dominant_event_id": -1,
+    "behavior_cluster_id": -1,
+    # 여정
+    "journey_stage_id": 0,
+    "days_in_current_stage": 0,
+    "purchase_count": 0,
+    "days_since_signup": 0,
+    "cart_abandon_count_recent": 0,
+    "cs_contact_count_recent": 0,
+}
+
+# 충전값이 명시되지 않은 수치형 피처는 median 으로 채운다.
+DEFAULT_NUMERIC_STRATEGY: str = "median"
+
+
+def handle_missing_values(
+    df: pd.DataFrame,
+    fill_map: dict[str, Any] | None = None,
+    default_strategy: str = DEFAULT_NUMERIC_STRATEGY,
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    """결측치 처리.
+
+    1) fill_map 에 정의된 컬럼은 정해진 상수로 채움
+    2) 그 외 수치형 컬럼은 median 으로 채움
+    3) 수치형이 아닌 컬럼은 'unknown' 또는 가장 빈번한 값으로 채움
+
+    Returns
+    -------
+    df_filled : 결측 처리된 DataFrame
+    report    : 컬럼별 결측 비율 및 충전 방식 dict
+    """
+    if fill_map is None:
+        fill_map = MISSING_FILL_VALUES
+
+    df = df.copy()
+    report: dict[str, Any] = {}
+
+    for col in df.columns:
+        if col == "customer_id":
+            continue
+        n_missing = int(df[col].isna().sum())
+        if n_missing == 0:
+            continue
+
+        missing_ratio = n_missing / len(df)
+        if col in fill_map:
+            df[col] = df[col].fillna(fill_map[col])
+            report[col] = {
+                "n_missing": n_missing,
+                "missing_ratio": round(missing_ratio, 4),
+                "strategy": "constant",
+                "fill_value": fill_map[col],
+            }
+        elif pd.api.types.is_numeric_dtype(df[col]):
+            if default_strategy == "median":
+                fill_val = float(df[col].median())
+            else:
+                fill_val = float(df[col].mean())
+            df[col] = df[col].fillna(fill_val)
+            report[col] = {
+                "n_missing": n_missing,
+                "missing_ratio": round(missing_ratio, 4),
+                "strategy": default_strategy,
+                "fill_value": round(fill_val, 4),
+            }
+        else:
+            mode_vals = df[col].mode()
+            fill_val = mode_vals.iloc[0] if not mode_vals.empty else "unknown"
+            df[col] = df[col].fillna(fill_val)
+            report[col] = {
+                "n_missing": n_missing,
+                "missing_ratio": round(missing_ratio, 4),
+                "strategy": "mode",
+                "fill_value": str(fill_val),
+            }
+
+    return df, report
+
+
+# ---------------------------------------------------------------------------
+# Outlier handling (winsorization)
+# ---------------------------------------------------------------------------
+
+# 윈저라이즈하지 않는 컬럼 (카테고리/플래그/식별자/스코어)
+NO_WINSOR_COLS: set[str] = {
+    "customer_id",
+    "rfm_r_score", "rfm_f_score", "rfm_m_score", "rfm_score",
+    "activity_decline_flag",
+    "journey_stage", "journey_stage_id",
+    "behavior_cluster_id",
+    "seq_dominant_event_id",
+    "seq_unique_event_types",
+}
+
+
+def handle_outliers(
+    df: pd.DataFrame,
+    low_q: float = WINSOR_LOW,
+    high_q: float = WINSOR_HIGH,
+    skip_cols: set[str] | None = None,
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    """이상치 처리: 분위수 기반 winsorization.
+
+    각 수치 컬럼에 대해 [low_q, high_q] 분위수 밖의 값을 경계로 클리핑.
+    카테고리/플래그/식별자(NO_WINSOR_COLS)는 skip.
+    np.inf / -np.inf 는 NaN 으로 대체 후 클리핑 (호출 전 결측 처리 권장).
+
+    Returns
+    -------
+    df_clipped : winsorize 된 DataFrame
+    report     : 컬럼별 클리핑 통계 dict
+    """
+    if skip_cols is None:
+        skip_cols = NO_WINSOR_COLS
+
+    df = df.copy()
+    report: dict[str, Any] = {}
+
+    df = df.replace([np.inf, -np.inf], INF_REPLACEMENT)
+
+    for col in df.columns:
+        if col in skip_cols:
+            continue
+        if not pd.api.types.is_numeric_dtype(df[col]):
+            continue
+        # 단일 값/상수 컬럼 skip
+        if df[col].nunique(dropna=True) <= 1:
+            continue
+
+        lo = df[col].quantile(low_q)
+        hi = df[col].quantile(high_q)
+        if pd.isna(lo) or pd.isna(hi) or lo == hi:
+            continue
+
+        n_clipped_low = int((df[col] < lo).sum())
+        n_clipped_high = int((df[col] > hi).sum())
+        if n_clipped_low + n_clipped_high == 0:
+            continue
+
+        df[col] = df[col].clip(lower=lo, upper=hi)
+        report[col] = {
+            "low_q": low_q,
+            "high_q": high_q,
+            "lo_value": round(float(lo), 4),
+            "hi_value": round(float(hi), 4),
+            "n_clipped_low": n_clipped_low,
+            "n_clipped_high": n_clipped_high,
+        }
+
+    return df, report
+
+
+# ---------------------------------------------------------------------------
+# Build & save feature store
+# ---------------------------------------------------------------------------
+
+def build_feature_store(
+    data_dir: str | Path = "data/raw",
+    output_dir: str | Path = "data/processed",
+    save: bool = True,
+) -> pd.DataFrame:
+    """전체 피처 파이프라인 실행 → 결측/이상치 처리 → 피처 스토어 저장.
+
+    저장 파일
+    ---------
+    data/processed/feature_store.parquet  (pyarrow 가능 시)
+    data/processed/feature_store.csv
+    data/processed/feature_store_meta.json
+    """
+    data_dir = Path(data_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print("[Store] Loading raw data...")
+    customers, events = _load_raw(data_dir)
+    analysis_date = get_analysis_date(events)
+    print(f"[Store] Customers: {len(customers):,}  Events: {len(events):,}")
+    print(f"[Store] Analysis date: {analysis_date.date()}")
+
+    # 1. 각 모듈 실행
+    print("[Store] Computing RFM + change-rate features...")
+    rfm_df = compute_rfm_features(customers, events, analysis_date)
+    change_df = compute_change_rate_features(customers, events, analysis_date)
+
+    print("[Store] Computing session + time features...")
+    session_df = compute_session_features(customers, events)
+    time_df = compute_time_features(customers, events)
+
+    print("[Store] Computing sequence + journey features...")
+    seq_df = compute_sequence_features(customers, events)
+    journey_df = compute_journey_features(customers, events, analysis_date)
+
+    # 2. 통합 (customer_id 기준 left join, customers 가 master)
+    fs = customers[["customer_id", "persona", "is_treatment", "churned"]].copy()
+    for d in [rfm_df, change_df, session_df, time_df, seq_df, journey_df]:
+        fs = fs.merge(d, on="customer_id", how="left")
+
+    print(f"[Store] Combined shape: {fs.shape}")
+
+    # 3. 결측 처리
+    fs, missing_report = handle_missing_values(fs)
+    print(f"[Store] Missing handled: {len(missing_report)} columns had NaNs")
+
+    # 4. 이상치 처리
+    fs, outlier_report = handle_outliers(fs)
+    print(f"[Store] Outliers winsorized: {len(outlier_report)} columns clipped")
+
+    # 5. 저장
+    if save:
+        meta = {
+            "analysis_date": str(analysis_date.date()),
+            "n_customers": int(len(fs)),
+            "n_features": int(fs.shape[1] - 4),  # exclude id/persona/is_treatment/churned
+            "missing_handling_report": missing_report,
+            "outlier_handling_report": outlier_report,
+            "feature_columns": [c for c in fs.columns if c not in {"customer_id", "persona", "is_treatment", "churned"}],
+        }
+
+        csv_path = output_dir / "feature_store.csv"
+        fs.to_csv(csv_path, index=False)
+        print(f"[Store] Saved CSV → {csv_path}")
+
+        # parquet 시도 (pyarrow 가용 시)
+        try:
+            parquet_path = output_dir / "feature_store.parquet"
+            fs.to_parquet(parquet_path, index=False)
+            print(f"[Store] Saved Parquet → {parquet_path}")
+        except (ImportError, ValueError) as e:
+            print(f"[Store] Skipped Parquet (no engine): {e}")
+
+        meta_path = output_dir / "feature_store_meta.json"
+        with open(meta_path, "w", encoding="utf-8") as f:
+            json.dump(meta, f, ensure_ascii=False, indent=2, default=str)
+        print(f"[Store] Saved meta → {meta_path}")
+
+    return fs
+
+
+def load_feature_store(
+    output_dir: str | Path = "data/processed",
+) -> pd.DataFrame:
+    """저장된 피처 스토어를 로드한다. parquet 우선, 없으면 csv."""
+    output_dir = Path(output_dir)
+    parquet_path = output_dir / "feature_store.parquet"
+    csv_path = output_dir / "feature_store.csv"
+
+    if parquet_path.exists():
+        try:
+            return pd.read_parquet(parquet_path)
+        except (ImportError, ValueError):
+            pass
+    if csv_path.exists():
+        return pd.read_csv(csv_path)
+    raise FileNotFoundError(
+        f"No feature store found in {output_dir}. Run build_feature_store first."
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build feature store with missing/outlier handling")
+    parser.add_argument("--data-dir", default="data/raw")
+    parser.add_argument("--output-dir", default="data/processed")
+    args = parser.parse_args()
+    fs = build_feature_store(data_dir=args.data_dir, output_dir=args.output_dir)
+    print(f"\n[Store] Final feature store: {fs.shape[0]:,} rows × {fs.shape[1]} cols")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/features/store.py
+++ b/src/features/store.py
@@ -60,6 +60,7 @@ INF_REPLACEMENT: float = np.nan
 # ---------------------------------------------------------------------------
 
 def _load_raw(data_dir: str | Path) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """시뮬레이터가 생성한 customers.csv / events.csv 를 로드하고 날짜 파싱."""
     data_dir = Path(data_dir)
     customers = pd.read_csv(data_dir / "customers.csv")
     events = pd.read_csv(data_dir / "events.csv")
@@ -384,6 +385,7 @@ def load_feature_store(
 # ---------------------------------------------------------------------------
 
 def main() -> None:
+    """CLI entry point for the integrated feature store pipeline."""
     parser = argparse.ArgumentParser(description="Build feature store with missing/outlier handling")
     parser.add_argument("--data-dir", default="data/raw")
     parser.add_argument("--output-dir", default="data/processed")


### PR DESCRIPTION
Closes #30

## 변경 사항
WBS 3.2~3.6 피처 엔지니어링 전체 구현.

### 추가 파일
- `src/features/__init__.py`
- `src/features/rfm.py` — RFM + 행동 변화율 피처
- `src/features/session.py` — 세션 + 시간대별 피처
- `src/features/sequence.py` — 시퀀스 + 여정 피처
- `src/features/store.py` — 결측/이상치 처리 + 통합 피처 스토어
- `docs/feature_dictionary.md` — 44개 피처 정의

## 명세서 체크리스트
- [x] RFM 피처 산출 (11개)
- [x] 행동 변화율 피처 5개 이상 → 7개
- [x] 구매 주기 이상 피처 (`purchase_cycle_anomaly`)
- [x] 세션 품질 피처 3개 이상 → 6개
- [x] 시퀀스 피처 2개 이상 → 6개
- [x] 시간대별 행동 피처 (주말/평일, 월초/월말)
- [x] 고객 여정 단계 + 체류 기간
- [x] 결측치/이상치 처리 로직
- [x] 피처 스토어 파일 저장 (parquet + csv + meta JSON)
- [x] feature_dictionary.md 30개 이상 → 44개

## 검증
시뮬레이터 small 데이터(500명, 31,017 이벤트) 기준:
- 44개 피처 모두 결측 없이 산출
- churned 상관관계 상위: `active_day_span` -0.76, `journey_stage_id` +0.66, `seq_entropy` -0.62 
- 결측 처리 27개 컬럼, winsorization 23개 컬럼 (메타 JSON에 통계 기록)

## 시뮬레이터 연동
- 입력 스키마: `simulator.py` 출력 그대로 (`customers.csv` 6컬럼, `events.csv` 6컬럼)
- 분석 기준일: `cohort.py` / `eda.ipynb`와 동일하게 `events 마지막일 + 1`
- 이벤트 vocab: `simulator_config.yaml` 8가지 이벤트와 일치

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive feature-engineering pipeline producing RFM metrics, behavior change-rate, session- and time-based quality indicators, sequence & behavior-cluster features, and customer-journey stage classifications.
  * Feature store builder with automatic missing-value imputation, outlier winsorization, multiple output formats (CSV/parquet) and metadata export, plus CLI for building/loading.

* **Documentation**
  * Added a feature dictionary detailing all generated features, formulas, business meanings, handling policies, outputs, and example usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->