### PR TITLE
feat(infra): python-dotenv 도입 및 docker env_file 통합

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   simulator:
     build: .
     container_name: churn-simulator
+    env_file:
+      - .env
     volumes:
       - ./data:/app/data
       - ./models:/app/models
@@ -12,6 +14,8 @@ services:
   validator:
     build: .
     container_name: churn-validator
+    env_file:
+      - .env
     depends_on:
       simulator:
         condition: service_completed_successfully
@@ -24,6 +28,8 @@ services:
   dashboard:
     build: .
     container_name: churn-dashboard
+    env_file:
+      - .env
     ports:
       - "8501:8501"
     depends_on:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,9 @@ shap>=0.46
 # CLV
 lifetimes>=0.11.3
 
+# Config / env
+python-dotenv>=1.0.0
+
 # Dashboard
 streamlit>=1.40
 plotly>=5.24

--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,20 @@ load_dotenv(PROJECT_ROOT / ".env")
 CONFIG_PATH = Path(__file__).parent.parent / "config" / "simulator_config.yaml"
 
 
+def _get_budget_default() -> float | None:
+    """BUDGET 환경변수를 안전하게 float로 변환. 없거나 잘못된 값이면 None 반환.
+
+    argparse의 --budget이 type=float로 선언되어 있으므로 동일 타입을 유지한다.
+    """
+    val = os.getenv("BUDGET")
+    if val is None or val.strip() == "":
+        return None
+    try:
+        return float(val)
+    except ValueError:
+        return None
+
+
 def run_simulate(sim_mode: str) -> None:
     """Run the data simulator and write raw CSVs to data/raw/."""
     from data.simulator import run_simulation
@@ -63,7 +77,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--budget",
         type=float,
-        default=int(os.environ["BUDGET"]) if os.getenv("BUDGET") else None,
+        default=_get_budget_default(),
         help="Marketing budget for optimization mode (env: BUDGET)",
     )
     return parser.parse_args()

--- a/src/main.py
+++ b/src/main.py
@@ -13,8 +13,13 @@ Usage
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+load_dotenv(PROJECT_ROOT / ".env")
 
 CONFIG_PATH = Path(__file__).parent.parent / "config" / "simulator_config.yaml"
 
@@ -46,20 +51,20 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--mode",
         choices=["simulate", "train", "uplift", "optimize"],
-        default="simulate",
-        help="Execution mode (default: simulate)",
+        default=os.getenv("APP_MODE", "simulate"),
+        help="Execution mode (default: simulate, env: APP_MODE)",
     )
     parser.add_argument(
         "--sim-mode",
         choices=["full", "small"],
-        default="full",
-        help="Simulator scale: full=20,000 customers / small=5,000 customers (default: full)",
+        default=os.getenv("SIM_MODE", "full"),
+        help="Simulator scale: full=20,000 customers / small=5,000 customers (default: full, env: SIM_MODE)",
     )
     parser.add_argument(
         "--budget",
         type=float,
-        default=None,
-        help="Marketing budget for optimization mode",
+        default=int(os.environ["BUDGET"]) if os.getenv("BUDGET") else None,
+        help="Marketing budget for optimization mode (env: BUDGET)",
     )
     return parser.parse_args()
 


### PR DESCRIPTION
- python-dotenv>=1.0.0 추가
- .env 파일 자동 로드를 위한 기반 라이브러리

Refs: #<issue-number>

- src/main.py에 load_dotenv() 호출 추가
- argparse 기본값을 환경변수로부터 읽도록 변경
  - APP_MODE → --mode default
  - SIM_MODE → --sim-mode default
  - BUDGET → --budget default
- 우선순위: CLI 인수 > 환경변수 > 기본값
- argparse 표준 동작에 의해 우선순위 자동 보장

Refs: #<issue-number>

- simulator, validator, dashboard 3개 서비스 모두에 env_file: .env 추가
- 기존 shell 변수 보간(${APP_MODE:-simulate})과 병행 유지
- 컨테이너 내부에서 .env 자동 주입

Refs: #<issue-number>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Environment variable configuration support has been added to the application and services. The simulator, validator, dashboard services, and CLI can now load customizable settings from a `.env` file. This includes application mode, simulation mode, and budget parameters, enabling flexible configuration across different deployment environments without requiring code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->