### PR TITLE
fix: 스크립트 직접 실행 방식으로 인한 절대 경로 임포트 참조 실패

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -24,13 +24,6 @@ from dotenv import load_dotenv
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SRC_DIR = PROJECT_ROOT / "src"
 
-# 두 실행 방식을 모두 지원:
-#   - python src/main.py        → src/ 가 자동 추가됨 + 아래서 PROJECT_ROOT 보강
-#   - python -m src.main        → PROJECT_ROOT 가 자동 추가됨 + 아래서 src/ 보강
-for _p in (str(PROJECT_ROOT), str(SRC_DIR)):
-    if _p not in sys.path:
-        sys.path.insert(0, _p)
-
 load_dotenv(PROJECT_ROOT / ".env")
 
 CONFIG_PATH = Path(__file__).parent.parent / "config" / "simulator_config.yaml"
@@ -150,4 +143,9 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    # sys.path 조작 로직을 이 위치로 이동시켜 직접 실행될 때만 작동하게 합니다.
+    for _p in (str(PROJECT_ROOT), str(SRC_DIR)):
+        if _p not in sys.path:
+            sys.path.insert(0, _p)
+
     main()

--- a/src/main.py
+++ b/src/main.py
@@ -16,11 +16,21 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / "src"
+
+# 두 실행 방식을 모두 지원:
+#   - python src/main.py        → src/ 가 자동 추가됨 + 아래서 PROJECT_ROOT 보강
+#   - python -m src.main        → PROJECT_ROOT 가 자동 추가됨 + 아래서 src/ 보강
+for _p in (str(PROJECT_ROOT), str(SRC_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
 load_dotenv(PROJECT_ROOT / ".env")
 
 CONFIG_PATH = Path(__file__).parent.parent / "config" / "simulator_config.yaml"
@@ -67,12 +77,14 @@ def run_train() -> None:
         run_feature()
 
     from main_train import main as _main_train
+
     _main_train()
 
 
 def run_uplift() -> None:
     """Run uplift modeling."""
     from models.uplift import main as _main_uplift
+
     _main_uplift()
 
 
@@ -98,9 +110,7 @@ def run_optimize(budget: float | None) -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Customer churn retention system entrypoint"
-    )
+    parser = argparse.ArgumentParser(description="Customer churn retention system entrypoint")
     parser.add_argument(
         "--mode",
         choices=["simulate", "feature", "train", "uplift", "optimize"],


### PR DESCRIPTION
src/main.py --mode train 실행했을 때 실행 실패

python src/main.py로 실행하면 Python이 src/를 sys.path에 추가
그 상태에서 src.models를 찾으려 하면 src/ 안에서 src라는 패키지가 보이지 않아서 실행 실패



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed module path handling so the application starts reliably across different launch methods and environments.
  * Preserved existing CLI behavior while improving startup robustness and reducing startup failures related to module resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/neibler/customer-churn-retention-system/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->