### PR TITLE
fix: 명령어 인자 파싱 충돌 문제 재수정

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,11 @@ from dotenv import load_dotenv
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SRC_DIR = PROJECT_ROOT / "src"
 
+for _p in (str(PROJECT_ROOT), str(SRC_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
 load_dotenv(PROJECT_ROOT / ".env")
 
 CONFIG_PATH = Path(__file__).parent.parent / "config" / "simulator_config.yaml"
@@ -143,9 +148,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    # sys.path 조작 로직을 이 위치로 이동시켜 직접 실행될 때만 작동하게 합니다.
-    for _p in (str(PROJECT_ROOT), str(SRC_DIR)):
-        if _p not in sys.path:
-            sys.path.insert(0, _p)
-
     main()


### PR DESCRIPTION
main.py에서 train 실행할때 명령어 인자 파싱 충돌 문제 발생

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized module initialization to ensure proper path resolution at load time rather than only during direct execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->