### PR TITLE
fix: 저가치-Sure Things 세그먼트 추가, CLV 검증 리포트 저장 (closes #100)

### DIFF
--- a/src/models/clv_predictor.py
+++ b/src/models/clv_predictor.py
@@ -6,6 +6,7 @@ BG/NBD + Gamma-Gamma 모델(Lifetimes 라이브러리)로 향후 12개월 고객
 ------
 results/clv_predictions.csv : customer_id, predicted_clv, clv_percentile, is_high_value
 results/clv_distribution.png : CLV 히스토그램
+results/clv_validation.json : MAE/MAPE 검증 리포트
 
 Usage
 -----
@@ -16,6 +17,7 @@ Usage
 from __future__ import annotations
 
 import argparse
+import json
 import warnings
 from pathlib import Path
 
@@ -221,6 +223,20 @@ def validate_clv(
     return {"mae": round(mae, 2), "mape": round(mape, 4)}
 
 
+def save_validation_report(metrics: dict[str, float], output_path: Path) -> None:
+    """CLV 검증 결과(MAE/MAPE)를 JSON 파일로 저장 — 발표/보고서용 산출물."""
+    report = {
+        "prediction_months": PREDICTION_MONTHS,
+        "monthly_discount_rate": MONTHLY_DISCOUNT_RATE,
+        "high_value_percentile": HIGH_VALUE_PERCENTILE,
+        "mae": metrics["mae"],
+        "mape": metrics["mape"],
+    }
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, ensure_ascii=False, indent=2)
+    print(f"[CLV] 검증 리포트 저장: {output_path}")
+
+
 def plot_clv_distribution(clv_df: pd.DataFrame, output_path: Path) -> None:
     """CLV 분포 히스토그램 + 고가치 고객 경계선."""
     fig, axes = plt.subplots(1, 2, figsize=(13, 5))
@@ -309,6 +325,7 @@ def run_clv_pipeline(
     metrics = validate_clv(purchases, obs_end, summary, bgf, ggf)
     print(f"[CLV] MAE: {metrics['mae']:,}  MAPE: {metrics['mape']:.2%}" if not np.isnan(metrics['mae'])
           else "[CLV] 검증 데이터 부족")
+    save_validation_report(metrics, output_dir / "clv_validation.json")
 
     # 8. 요약 출력
     high_val = all_customers[all_customers["is_high_value"] == 1]

--- a/src/uplift/segmentation.py
+++ b/src/uplift/segmentation.py
@@ -1,6 +1,7 @@
-"""6세그먼트 분류 & 우선순위 점수 — Task 2.20 (배한나).
+"""세그먼트 분류 & 우선순위 점수 — Task 2.20 (배한나).
 
-이탈 확률 × Uplift Score × CLV 기반 6세그먼트 분류.
+이탈 확률 × Uplift Score × CLV 기반 세그먼트 분류 (고/저가치 × Persuadables/
+Sure Things/Lost Causes 6종 + 신규고객 = 총 7종).
 uplift_segments.csv + clv_predictions.csv를 읽어 통합 결과 생성.
 
 산출물
@@ -40,6 +41,7 @@ SEGMENT_COLORS = {
     "고가치-Sure Things":  "#388E3C",
     "고가치-Lost Causes":  "#FF6F00",
     "저가치-Persuadables": "#1565C0",
+    "저가치-Sure Things":  "#90CAF9",
     "저가치-Lost Causes":  "#9E9E9E",
     "신규고객":            "#7B1FA2",
 }
@@ -49,8 +51,9 @@ SEGMENT_PRIORITY = {
     "고가치-Sure Things":  2,
     "고가치-Lost Causes":  3,
     "저가치-Persuadables": 4,
-    "저가치-Lost Causes":  5,
-    "신규고객":            6,
+    "저가치-Sure Things":  5,
+    "저가치-Lost Causes":  6,
+    "신규고객":            7,
 }
 
 
@@ -79,7 +82,7 @@ def load_inputs(output_dir: Path, data_dir: Path) -> tuple[pd.DataFrame, pd.Time
 
 
 def classify_6segment(df: pd.DataFrame, obs_end: pd.Timestamp | None = None) -> pd.Series:
-    """이탈 확률 × Uplift × CLV 기반 6세그먼트 분류.
+    """이탈 확률 × Uplift × CLV 기반 세그먼트 분류.
 
     분류 기준 (우선순위 순)
     ─────────────────────────────────────────────────────
@@ -88,7 +91,8 @@ def classify_6segment(df: pd.DataFrame, obs_end: pd.Timestamp | None = None) -> 
     3. 고가치-Sure Things : is_high_value=1 & 4분면=Sure Things  (유지 관리)
     4. 고가치-Lost Causes : is_high_value=1 & 4분면=Lost Causes  (심층 분석)
     5. 저가치-Persuadables: is_high_value=0 & 4분면=Persuadables (비용 효율 개입)
-    6. 저가치-Lost Causes : 나머지 이탈 위험 고객
+    6. 저가치-Sure Things : is_high_value=0 & 4분면=Sure Things  (저비용 유지)
+    7. 저가치-Lost Causes : 나머지 이탈 위험 고객
     ─────────────────────────────────────────────────────
     """
     # 관찰 기간 종료일 기준으로 신규고객 판별 (signup_date.max() 사용 시 편향 발생)
@@ -105,6 +109,7 @@ def classify_6segment(df: pd.DataFrame, obs_end: pd.Timestamp | None = None) -> 
 
     # 우선순위 역순으로 덮어씀 (마지막이 최우선)
     seg[is_lost & ~is_high]                    = "저가치-Lost Causes"
+    seg[is_sure_thing & ~is_high]              = "저가치-Sure Things"
     seg[is_persuadable & ~is_high]             = "저가치-Persuadables"
     seg[is_lost & is_high]                     = "고가치-Lost Causes"
     seg[is_sure_thing & is_high]               = "고가치-Sure Things"


### PR DESCRIPTION
## 변경 사항

### N18 — 세그먼트 5종만 생성됨 (#5-8 "최소 6개" 미달)
`classify_6segment`에 `저가치-Sure Things` 분류 조건이 없어 default(`저가치-Lost Causes`)로 흡수되던 문제 수정.
- `classify_6segment`에 `is_sure_thing & ~is_high` → `저가치-Sure Things` 조건 추가
- `SEGMENT_COLORS`, `SEGMENT_PRIORITY`에 항목 추가 (6종 → 7종, 신규고객 포함)

### C3 — CLV MAE/MAPE를 파일로 저장
검증 로직(`validate_clv`)은 있었으나 결과가 stdout으로만 출력되어 산출물이 없던 문제 수정.
- `save_validation_report()` 함수 추가
- `results/clv_validation.json`으로 MAE/MAPE 저장

Closes #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customer lifecycle value predictions now generate a validation metrics report in JSON format for tracking model accuracy
  * Customer segmentation framework expanded from 6 to 7 distinct segments with refined priority classifications and an additional customer category

<!-- end of auto-generated comment: release notes by coderabbit.ai -->