### PR TITLE
fix: shap-xgboost 버전충돌

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pyyaml>=6.0
 
 # ML
 scikit-learn>=1.5
-xgboost>=2.0
+xgboost>=2.0,<3.0
 lightgbm>=4.3
 imbalanced-learn>=0.11
 optuna>=3.4


### PR DESCRIPTION
shap-xgboost 버전충돌로 results/shap_summary.png가 생성되지 않았다.

xgboost ≥ 3.0.0부터 base_score를 float이 아니라 "[0.5]" 같은 JSON 리스트로 저장하는데, shap.TreeExplainer()는 이를 float으로 변환하려다 ValueError 발생



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined xgboost dependency version constraint to prevent unexpected compatibility issues with future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->